### PR TITLE
flatpak-builder: Bump image and builder version

### DIFF
--- a/.github/workflows/flatpak-builder.yml
+++ b/.github/workflows/flatpak-builder.yml
@@ -8,11 +8,11 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
     - uses: actions/checkout@v3
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: hu.kramo.Cartridges.flatpak
         manifest-path: hu.kramo.Cartridges.json


### PR DESCRIPTION
## Changes

- Bump the image version to gnome 44.
- Bump the builder version to `v6`.

Reference Build (from my fork): https://github.com/kbdharun/cartridges/actions/runs/4587516380