### PR TITLE
[Fix] GOG library path

### DIFF
--- a/src/importers/heroic_importer.py
+++ b/src/importers/heroic_importer.py
@@ -137,7 +137,7 @@ def heroic_importer(win):
                 continue
 
             # Get game title and developer from library.json as they are not present in installed.json
-            library = json.load((heroic_dir / "gog_store" / "library.json").open())
+            library = json.load((heroic_dir / "store_cache" / "gog_library.json").open())
             for game in library["games"]:
                 if game["app_name"] == app_name:
                     values["developer"] = game["developer"]


### PR DESCRIPTION
Heroic v2.7.0 uses a new and updated path for the GOG library json file. I've noticed that `library.json` in the previous path is now either empty for old users or never created for new users.  

I was wondering why my GOG games weren't detected and this was the resulting error:
```
Traceback (most recent call last):
  File "/app/share/cartridges/cartridges/main.py", line 222, in on_import_action
    heroic_importer(self.win)
  File "/app/share/cartridges/cartridges/heroic_importer.py", line 142, in heroic_importer
    for game in library["games"]:
KeyError: 'games'
```

This PR fixes this issue.