### PR TITLE
i18n: Add details_window.blp to POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,6 +2,7 @@ data/hu.kramo.Cartridges.desktop.in
 data/hu.kramo.Cartridges.gschema.xml
 data/hu.kramo.Cartridges.metainfo.xml.in
 
+data/gtk/details_window.blp
 data/gtk/game.blp
 data/gtk/help-overlay.blp
 data/gtk/preferences.blp


### PR DESCRIPTION
Add missing details_window.blp to the POTFILES to make it translatable.

Fixes: #96