### PR TITLE
Logging improvements

### DIFF
--- a/src/logging/setup.py
+++ b/src/logging/setup.py
@@ -35,7 +35,7 @@ def setup_logging():
     app_log_level = os.environ.get("LOGLEVEL", profile_app_log_level).upper()
     lib_log_level = os.environ.get("LIBLOGLEVEL", profile_lib_log_level).upper()
 
-    log_filename = shared.cache_dir / "cartridges" / "logs" / "cartridges.log.xz"
+    log_filename = shared.cache_dir / "cartridges" / "logs" / "cartridges.xz"
 
     config = {
         "version": 1,

--- a/src/logging/setup.py
+++ b/src/logging/setup.py
@@ -35,7 +35,7 @@ def setup_logging():
     app_log_level = os.environ.get("LOGLEVEL", profile_app_log_level).upper()
     lib_log_level = os.environ.get("LIBLOGLEVEL", profile_lib_log_level).upper()
 
-    log_filename = shared.cache_dir / "cartridges" / "logs" / "cartridges.xz"
+    log_filename = shared.cache_dir / "cartridges" / "logs" / "cartridges.log"
 
     config = {
         "version": 1,

--- a/src/main.py
+++ b/src/main.py
@@ -145,7 +145,11 @@ class CartridgesApplication(Adw.Application):
     def on_about_action(self, *_args):
         # Get the debug info from the log files
         debug_str = ""
-        for path in shared.log_files:
+        for i, path in enumerate(shared.log_files):
+            # Add a horizontal line between runs
+            if i > 0:
+                debug_str += "─" * 37 + "\n"
+            # Add the run's logs
             log_file = (
                 lzma.open(path, "rt", encoding="utf-8")
                 if path.name.endswith(".xz")

--- a/src/main.py
+++ b/src/main.py
@@ -143,10 +143,16 @@ class CartridgesApplication(Adw.Application):
                 shared.store.add_game(game, {"skip_save": True})
 
     def on_about_action(self, *_args):
+        # Get the debug info from the log files
         debug_str = ""
         for path in shared.log_files:
-            log_file = lzma.open(path, "rt", encoding="utf-8")
+            log_file = (
+                lzma.open(path, "rt", encoding="utf-8")
+                if path.name.endswith(".xz")
+                else open(path, "r", encoding="utf-8")
+            )
             debug_str += log_file.read()
+            log_file.close()
 
         about = Adw.AboutWindow(
             transient_for=self.win,


### PR DESCRIPTION
- Changed the log files format: `cartridges.log.xz.1 ` →  `cartridges.log.1.xz`
- Compress old log files at startup when the rotation happens instead of compressing on the fly
- Cleaned-up the SessionFileHandler code
-  Added debug info to the AboutWindow (runs are separated with hoirizontal lines)