### PR TITLE
Windows fixes

### DIFF
--- a/src/logging/session_file_handler.py
+++ b/src/logging/session_file_handler.py
@@ -88,16 +88,20 @@ class SessionFileHandler(StreamHandler):
 
         # If uncompressed, compress
         if not path.name.endswith(".xz"):
-            new_path = path.with_suffix(path.suffix + ".xz")
+            compressed_path = path.with_suffix(path.suffix + ".xz")
             with (
                 lzma.open(
-                    new_path, "wt", format=FORMAT_XZ, preset=PRESET_DEFAULT
+                    compressed_path,
+                    "wt",
+                    format=FORMAT_XZ,
+                    preset=PRESET_DEFAULT,
+                    encoding="utf-8",
                 ) as lzma_file,
                 open(path, "r", encoding="utf-8") as original_file,
             ):
                 lzma_file.write(original_file.read())
             path.unlink()
-            path = new_path
+            path = compressed_path
 
         # Rename with new number suffix
         new_number = self.get_path_number(path) + 1

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -143,7 +143,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             source = source_class()
             if not source.is_available:
                 expander_row = getattr(self, f"{source.id}_expander_row")
-                expander_row.remove()
+                expander_row.set_visible(False)
             else:
                 self.init_source_row(source)
 


### PR DESCRIPTION
- Fix logging not initializing on windows, needed explicit `utf-8` encoding
- Fix unavailable source rows in preferences, now using `set_visible(False)` 