### PR TITLE
RetroArch executable improvement

### DIFF
--- a/src/importer/sources/flatpak_source.py
+++ b/src/importer/sources/flatpak_source.py
@@ -26,7 +26,7 @@ from gi.repository import GLib, Gtk
 from src import shared
 from src.game import Game
 from src.importer.sources.location import Location, LocationSubPath
-from src.importer.sources.source import Source, SourceIterable
+from src.importer.sources.source import ExecutableFormatSource, SourceIterable
 
 
 class FlatpakSourceIterable(SourceIterable):
@@ -116,7 +116,7 @@ class FlatpakLocations(NamedTuple):
     data: Location
 
 
-class FlatpakSource(Source):
+class FlatpakSource(ExecutableFormatSource):
     """Generic Flatpak source"""
 
     source_id = "flatpak"

--- a/src/importer/sources/legendary_source.py
+++ b/src/importer/sources/legendary_source.py
@@ -26,7 +26,11 @@ from typing import NamedTuple
 from src import shared
 from src.game import Game
 from src.importer.sources.location import Location, LocationSubPath
-from src.importer.sources.source import Source, SourceIterationResult, SourceIterable
+from src.importer.sources.source import (
+    ExecutableFormatSource,
+    SourceIterationResult,
+    SourceIterable,
+)
 
 
 class LegendarySourceIterable(SourceIterable):
@@ -93,7 +97,7 @@ class LegendaryLocations(NamedTuple):
     config: Location
 
 
-class LegendarySource(Source):
+class LegendarySource(ExecutableFormatSource):
     source_id = "legendary"
     name = _("Legendary")
     executable_format = "legendary launch {app_name}"

--- a/src/importer/sources/retroarch_source.py
+++ b/src/importer/sources/retroarch_source.py
@@ -172,7 +172,8 @@ class RetroarchSource(Source):
 
     def __init__(self) -> None:
         super().__init__()
-        self.add_steam_location_candidate()
+        # TODO enable when we get the Steam RetroArch games work
+        # self.add_steam_location_candidate()
 
     def add_steam_location_candidate(self) -> None:
         """Add the Steam RetroAcrh location to the config candidates"""
@@ -231,12 +232,13 @@ class RetroarchSource(Source):
 
         # Steam RetroArch
         # (Must check before Flatpak, because Steam itself can be installed as one)
-        if self.locations.config.root.parent.parent.name == "steamapps":
-            # steam://run exepects args to be url-encoded and separated by spaces.
-            args = map(lambda s: url_quote(str(s), safe=""), args)
-            args_str = " ".join(args)
-            uri = f"steam://run/1118310//{args_str}/"
-            return f"xdg-open {shell_quote(uri)}"
+        # TODO enable when we get Steam RetroArch executable to work
+        # if self.locations.config.root.parent.parent.name == "steamapps":
+        #     # steam://run exepects args to be url-encoded and separated by spaces.
+        #     args = map(lambda s: url_quote(str(s), safe=""), args)
+        #     args_str = " ".join(args)
+        #     uri = f"steam://run/1118310//{args_str}/"
+        #     return f"xdg-open {shell_quote(uri)}"
 
         # Flatpak RetroArch
         args = map(lambda s: shell_quote(str(s)), args)

--- a/src/importer/sources/retroarch_source.py
+++ b/src/importer/sources/retroarch_source.py
@@ -170,6 +170,11 @@ class RetroarchSource(Source):
 
     def __init__(self) -> None:
         super().__init__()
+        # TODO enable when RetroArch Steam's executable issue is resolved
+        # self.add_steam_location_candidate()
+
+    def add_steam_location_candidate(self) -> None:
+        """Add the Steam RetroAcrh location to the config candidates"""
         try:
             self.locations.config.candidates.append(self.get_steam_location())
         except (OSError, KeyError, UnresolvableLocationError):
@@ -225,16 +230,10 @@ class RetroarchSource(Source):
 
         # Steam RetroArch
         # (Must check before Flatpak, because Steam itself can be installed as one)
-        if self.locations.config.root.parent.parent.name == "steamapps":
-            # TODO fix the RetroArch Steam arguments
-            # It seems that the space after "-L" is parsed as the value for that arg.
-            # The URI protocol is proprietary, a community doc is available:
-            # https://developer.valvesoftware.com/wiki/Steam_browser_protocol
-            # ... But it doesn't sepcify HOW the args should be formatted.
-            # Space delimited? Quoted individually? URL-Encoded?
-            # I don't know. It no workie :D
-            uri = f"steam://run/1118310//{args}/"
-            return f'xdg-open "{uri}"'
+        # TODO enable if/when we can pass args with steam://run
+        # if self.locations.config.root.parent.parent.name == "steamapps":
+        #     uri = f"steam://run/1118310//{args}/"
+        #     return f'xdg-open "{uri}"'
 
         # Flatpak RetroArch
         if self.locations.config.root.is_relative_to(shared.flatpak_dir):

--- a/src/importer/sources/retroarch_source.py
+++ b/src/importer/sources/retroarch_source.py
@@ -26,8 +26,6 @@ from pathlib import Path
 from time import time
 from typing import NamedTuple
 
-from urllib.parse import quote
-
 from src import shared
 from src.errors.friendly_error import FriendlyError
 from src.game import Game
@@ -223,13 +221,20 @@ class RetroarchSource(Source):
         """
 
         self.locations.config.resolve()
-        args = f'-L "{core_path}" "{rom_path}"'
+        args = f"-L '{core_path}' '{rom_path}'"
 
         # Steam RetroArch
         # (Must check before Flatpak, because Steam itself can be installed as one)
         if self.locations.config.root.parent.parent.name == "steamapps":
-            uri = "steam://run/1118310//" + quote(args) + "/"
-            return f"xdg-open {uri}"
+            # TODO fix the RetroArch Steam arguments
+            # It seems that the space after "-L" is parsed as the value for that arg.
+            # The URI protocol is proprietary, a community doc is available:
+            # https://developer.valvesoftware.com/wiki/Steam_browser_protocol
+            # ... But it doesn't sepcify HOW the args should be formatted.
+            # Space delimited? Quoted individually? URL-Encoded?
+            # I don't know. It no workie :D
+            uri = f"steam://run/1118310//{args}/"
+            return f'xdg-open "{uri}"'
 
         # Flatpak RetroArch
         if self.locations.config.root.is_relative_to(shared.flatpak_dir):

--- a/src/importer/sources/retroarch_source.py
+++ b/src/importer/sources/retroarch_source.py
@@ -151,6 +151,31 @@ class RetroarchSource(Source):
 
     def __init__(self) -> None:
         super().__init__()
+        self.locations = RetroarchLocations(
+            Location(
+                schema_key="retroarch-location",
+                candidates=[
+                    shared.flatpak_dir
+                    / "org.libretro.RetroArch"
+                    / "config"
+                    / "retroarch",
+                    shared.config_dir / "retroarch",
+                    shared.home / ".config" / "retroarch",
+                    # TODO: Windows support, waiting for executable path setting improvement
+                    # Path("C:\\RetroArch-Win64"),
+                    # Path("C:\\RetroArch-Win32"),
+                    # TODO: UWP support (URL handler - https://github.com/libretro/RetroArch/pull/13563)
+                    # shared.local_appdata_dir
+                    # / "Packages"
+                    # / "1e4cf179-f3c2-404f-b9f3-cb2070a5aad8_8ngdn9a6dx1ma"
+                    # / "LocalState",
+                ],
+                paths={
+                    "retroarch.cfg": LocationSubPath("retroarch.cfg"),
+                },
+                invalid_subtitle=Location.CONFIG_INVALID_SUBTITLE,
+            )
+        )
         # TODO enable when we get the Steam RetroArch games work
         # self.add_steam_location_candidate()
 

--- a/src/importer/sources/source.py
+++ b/src/importer/sources/source.py
@@ -75,10 +75,12 @@ class Source(Iterable):
     def is_available(self):
         return sys.platform in self.available_on
 
-    @property
     @abstractmethod
-    def executable_format(self) -> str:
-        """The executable format used to construct game executables"""
+    def make_executable(self, *args, **kwargs) -> str:
+        """
+        Create a game executable command.
+        Should be implemented by child classes.
+        """
 
     def __iter__(self) -> Generator[SourceIterationResult, None, None]:
         """
@@ -93,8 +95,21 @@ class Source(Iterable):
         return iter(self.iterable_class(self))
 
 
+class ExecutableFormatSource(Source):
+    """Source class that uses a simple executable format to start games"""
+
+    @property
+    @abstractmethod
+    def executable_format(self) -> str:
+        """The executable format used to construct game executables"""
+
+    def make_executable(self, *args, **kwargs) -> str:
+        """Use the executable format to"""
+        return self.executable_format.format(args, kwargs)
+
+
 # pylint: disable=abstract-method
-class URLExecutableSource(Source):
+class URLExecutableSource(ExecutableFormatSource):
     """Source class that use custom URLs to start games"""
 
     url_format: str


### PR DESCRIPTION
## Improvements to the RetroArch executable creation

- Creation of `ExecutableFomatSource` base class
- Creation of `Source.make_executable` method to override for generic executables (not URIs and not templates)
- Disabled RetroArch Steam until we understand and fix the `steam://run` to pass args

## About the `steam://run` issue.

We couldn't figure out how to pass the `-L /core/path /rom/path` args to the Steam RetroArch app. [Valve's docs](https://developer.valvesoftware.com/wiki/Steam_browser_protocol) barely contains anything and [a grep.app search](https://grep.app/search?q=steam%3A%2F%2Frun%2F) reveals only a few more bits of information.  

There are still many blocking points to crack that riddle

- How to pass positional args after named args?
- How should the args be named?
- Should the values be quoted? URI-encoed?
- ~~How do people work with those half-finished proprietary software docs?~~

## State of that PR

I want to work on it for a few hours tomorrow (2023-08-15) and hopefully fix the Steam RetroArch variant.   
If I can't fix it then, it will stay commented-out and v2.2 will be released without Steam RetroArch.

PS: The [2012 vulnerability paper](https://revuln.com/files/ReVuln_Steam_Browser_Protocol_Insecurity.pdf) mentioned by Valve describes the format a little bit more, I need to look more into that.