### PR TITLE
Add option to preserve image aspect ratio

### DIFF
--- a/data/gtk/preferences.blp
+++ b/data/gtk/preferences.blp
@@ -44,6 +44,16 @@ template $PreferencesWindow : Adw.PreferencesWindow {
           valign: center;
         }
       }
+
+      Adw.ActionRow {
+        title: _("Stretch Images To Fit");
+        subtitle: _("Stretch images to the desired aspect ratio");
+        activatable-widget: stretch_images_switch;
+
+        Switch stretch_images_switch {
+          valign: center;
+        }
+      }
     }
 
     Adw.PreferencesGroup danger_zone_group {

--- a/data/hu.kramo.Cartridges.gschema.xml.in
+++ b/data/hu.kramo.Cartridges.gschema.xml.in
@@ -20,6 +20,9 @@
     <key name="high-quality-images" type="b">
       <default>false</default>
     </key>
+    <key name="stretch-images" type="b">
+      <default>true</default>
+    </key>
     <key name="remove-missing" type="b">
       <default>true</default>
     </key>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -54,6 +54,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     exit_after_launch_switch = Gtk.Template.Child()
     cover_launches_game_switch = Gtk.Template.Child()
     high_quality_images_switch = Gtk.Template.Child()
+    stretch_images_switch = Gtk.Template.Child()
 
     remove_missing_switch = Gtk.Template.Child()
 
@@ -225,6 +226,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 "exit-after-launch",
                 "cover-launches-game",
                 "high-quality-images",
+                "stretch-images",
                 "remove-missing",
                 "lutris-import-steam",
                 "lutris-import-flatpak",


### PR DESCRIPTION
This resolves #177 by adding an option to preserve image aspect ratio by cropping to 2:3 before resize instead of stretching. The new option is presented as a switch to allow or disallow stretching, and this switch is turned on by default to preserve the current behavior.

![preferences](https://github.com/kra-mo/cartridges/assets/73746653/c2b5f933-9d9c-4735-bf86-23616d0073f0)

I tested the new setting by adding the following square (200x200) image with and without stretching disabled:

![square-pepper](https://github.com/kra-mo/cartridges/assets/73746653/c7b38140-b913-45c8-a8a7-5ea887eac2b1)

The result can be seen here:

![comparison](https://github.com/kra-mo/cartridges/assets/73746653/1ee5f6b0-2840-4c4b-b390-ad2b19f3c971)

Obviously a bit of the image is lost when cropping. This can be less than ideal when the original dimensions are wide enough that a significant amount of the image is lost, but stretching a significantly wider-than-2:3 image also has its drawbacks. In either case, using images with an aspect ratio somewhat close to 2:3 is best.

As a more practical example, we can use the official box art for _Darkula_ (from https://locomalito.com/darkula.php), which is 600x850 — _close_ to 2:3 but not exactly — and notably displays a circle.

![comparison-darkula](https://github.com/kra-mo/cartridges/assets/73746653/2a9b59df-4489-4ec2-a0f0-e1b2b9a34f51)

I can tell that the circle is no longer perfectly circular with the default setting. With stretching disabled, the aspect ratio of the circle is preserved, and no valuable image content is lost.