### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -24,10 +24,6 @@
   <recommends>
     <display_length compare="gt">280</display_length>
   </recommends>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/kra-mo/cartridges/main/data/screenshots/1.png</image>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476