### PR TITLE
Appstream related patches

### DIFF
--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -17,22 +17,6 @@
   <developer_name translatable="no">kramo</developer_name>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">cartridges</translation>
-  <categories>
-    <category>GNOME</category>
-    <category>GTK</category>
-    <category>Game</category>
-  </categories>
-  <keywords>
-    <keyword>gaming</keyword>
-    <keyword>launcher</keyword>
-    <keyword translate="no">Steam</keyword>
-    <keyword translate="no">Lutris</keyword>
-    <keyword>Bottles</keyword>
-    <keyword translate="no">itch</keyword>
-    <keyword translate="no">Flatpak</keyword>
-    <keyword translate="no">Legendary</keyword>
-    <keyword translate="no">Retroarch</keyword>
-  </keywords>
   <supports>
     <control>pointing</control>
     <control>keyboard</control>

--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -16,6 +16,23 @@
   <url type="contribute">https://github.com/kra-mo/cartridges/blob/main/CONTRIBUTING.md</url>
   <developer_name translatable="no">kramo</developer_name>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
+  <translation type="gettext">cartridges</translation>
+  <categories>
+    <category>GNOME</category>
+    <category>GTK</category>
+    <category>Game</category>
+  </categories>
+  <keywords>
+    <keyword>gaming</keyword>
+    <keyword>launcher</keyword>
+    <keyword translate="no">steam</keyword>
+    <keyword translate="no">lutris</keyword>
+    <keyword>bottles</keyword>
+    <keyword translate="no">itch</keyword>
+    <keyword translate="no">flatpak</keyword>
+    <keyword translate="no">legendary</keyword>
+    <keyword translate="no">retroarch</keyword>
+  </keywords>
   <supports>
     <control>pointing</control>
     <control>keyboard</control>

--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -25,13 +25,13 @@
   <keywords>
     <keyword>gaming</keyword>
     <keyword>launcher</keyword>
-    <keyword translate="no">steam</keyword>
-    <keyword translate="no">lutris</keyword>
-    <keyword>bottles</keyword>
+    <keyword translate="no">Steam</keyword>
+    <keyword translate="no">Lutris</keyword>
+    <keyword>Bottles</keyword>
     <keyword translate="no">itch</keyword>
-    <keyword translate="no">flatpak</keyword>
-    <keyword translate="no">legendary</keyword>
-    <keyword translate="no">retroarch</keyword>
+    <keyword translate="no">Flatpak</keyword>
+    <keyword translate="no">Legendary</keyword>
+    <keyword translate="no">Retroarch</keyword>
   </keywords>
   <supports>
     <control>pointing</control>

--- a/data/meson.build
+++ b/data/meson.build
@@ -52,9 +52,9 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util, args: ['validate', appstream_file])
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli, args: ['validate', appstream_file])
 endif
 
 install_data(


### PR DESCRIPTION
### appdata: use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Update appdata

- Add translation tag
- Add categories and keywords tags
