### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -16,7 +16,7 @@
   <url type="contribute">https://github.com/kra-mo/cartridges/blob/main/CONTRIBUTING.md</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">kramo</developer_name>
-  <developer id="github.com">
+  <developer id="kramo.hu">
       <name translatable="no">kramo</name>
   </developer>
   <project_group>GNOME</project_group>

--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -14,7 +14,11 @@
   <url type="contact">https://www.kramo.hu/about/</url>
   <url type="vcs-browser">https://github.com/kra-mo/cartridges</url>
   <url type="contribute">https://github.com/kra-mo/cartridges/blob/main/CONTRIBUTING.md</url>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">kramo</developer_name>
+  <developer id="github.com">
+      <name translatable="no">kramo</name>
+  </developer>
   <project_group>GNOME</project_group>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">cartridges</translation>

--- a/data/meson.build
+++ b/data/meson.build
@@ -54,7 +54,11 @@ appstream_file = i18n.merge_file(
 
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
-  test('Validate appstream file', appstreamcli, args: ['validate', appstream_file])
+  test('Validate appstream file',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
+  )
 endif
 
 install_data(

--- a/flatpak/hu.kramo.Cartridges.Devel.json
+++ b/flatpak/hu.kramo.Cartridges.Devel.json
@@ -123,6 +123,7 @@
             "name" : "cartridges",
             "builddir" : true,
             "buildsystem" : "meson",
+            "run-tests" : true,
             "config-opts": [
                 "-Dprofile=development"
             ],


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli parameters
- Activate meson tests on Flatpak manifest