### PR TITLE
Added option to control whether game titles are displayed

### DIFF
--- a/cartridges/game.py
+++ b/cartridges/game.py
@@ -71,6 +71,7 @@ class Game(Gtk.Box):
         self.base_source = self.source.split("_")[0]
 
         self.set_play_icon()
+        self.update_title_shown()
 
         self.event_contoller_motion = Gtk.EventControllerMotion.new()
         self.add_controller(self.event_contoller_motion)
@@ -190,9 +191,17 @@ class Game(Gtk.Box):
             else "media-playback-start-symbolic"
         )
 
+    def update_title_shown(self) -> None:
+        self.title.hide()
+
+        if shared.schema.get_boolean("show-game-title"):
+            self.title.show()
+
     def schema_changed(self, _settings: Any, key: str) -> None:
         if key == "cover-launches-game":
             self.set_play_icon()
+        elif key == "show-game-title":
+            self.update_title_shown()
 
     @GObject.Signal(name="update-ready", arg_types=[object])
     def update_ready(self, _additional_data):  # type: ignore

--- a/cartridges/preferences.py
+++ b/cartridges/preferences.py
@@ -55,6 +55,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     exit_after_launch_switch = Gtk.Template.Child()
     cover_launches_game_switch = Gtk.Template.Child()
     high_quality_images_switch = Gtk.Template.Child()
+    show_game_title_switch = Gtk.Template.Child()
 
     remove_missing_switch = Gtk.Template.Child()
 
@@ -226,6 +227,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 "exit-after-launch",
                 "cover-launches-game",
                 "high-quality-images",
+                "show-game-title",
                 "remove-missing",
                 "lutris-import-steam",
                 "lutris-import-flatpak",

--- a/data/gtk/preferences.blp
+++ b/data/gtk/preferences.blp
@@ -28,6 +28,11 @@ template $PreferencesWindow : Adw.PreferencesWindow {
         title: _("High Quality Images");
         subtitle: _("Save game covers losslessly at the cost of storage");
       }
+
+      Adw.SwitchRow show_game_title_switch {
+        title: _("Game Title");
+        subtitle: _("Display game title below cover image");
+      }
     }
 
     Adw.PreferencesGroup danger_zone_group {

--- a/data/hu.kramo.Cartridges.gschema.xml.in
+++ b/data/hu.kramo.Cartridges.gschema.xml.in
@@ -14,6 +14,9 @@
     <key name="remove-missing" type="b">
       <default>true</default>
     </key>
+    <key name="show-game-title" type="b">
+      <default>true</default>
+    </key>
     <key name="steam" type="b">
       <default>true</default>
     </key>


### PR DESCRIPTION
Preview of a game card with the option disabled:
![image](https://github.com/kra-mo/cartridges/assets/47093312/0716646c-3bbb-4bca-b1c7-7ff42bffe4b1)

Partially fixes #196