### PR TITLE
Remove flatpak from desktop keywords

### DIFF
--- a/data/hu.kramo.Cartridges.desktop.in
+++ b/data/hu.kramo.Cartridges.desktop.in
@@ -7,5 +7,5 @@ Icon=@APP_ID@
 Terminal=false
 Type=Application
 Categories=GNOME;GTK;Game;
-Keywords=gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;legendary;retroarch;
+Keywords=gaming;launcher;steam;lutris;heroic;bottles;itch;legendary;retroarch;
 StartupNotify=true


### PR DESCRIPTION
Cartridges shouldn't be listed on a desktop search for flatpak. 
![Screenshot from 2024-01-08 22-12-21](https://github.com/kra-mo/cartridges/assets/334272/a3f60772-db46-45fc-8e6a-95e1bfc9949f)
