### PR TITLE
Update developer ID

### DIFF
--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -16,7 +16,7 @@
   <url type="contribute">https://github.com/kra-mo/cartridges/blob/main/CONTRIBUTING.md</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">kramo</developer_name>
-  <developer id="kramo.page">
+  <developer id="page.kramo">
       <name translatable="no">kramo</name>
   </developer>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDds.

More information: ximion/appstream#575

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer