### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/hu.kramo.Cartridges.metainfo.xml.in
+++ b/data/hu.kramo.Cartridges.metainfo.xml.in
@@ -15,9 +15,9 @@
   <url type="vcs-browser">https://github.com/kra-mo/cartridges</url>
   <url type="contribute">https://github.com/kra-mo/cartridges/blob/main/CONTRIBUTING.md</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">kramo</developer_name>
+  <developer_name translate="no">kramo</developer_name>
   <developer id="page.kramo">
-      <name translatable="no">kramo</name>
+      <name translate="no">kramo</name>
   </developer>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">cartridges</translation>
@@ -54,7 +54,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="2.8.1" date="2024-03-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixes an issue with Lutris games not importing</li>
           <li>Fixes an issue with file chooser buttons being unresponsive</li>
@@ -62,27 +62,27 @@
       </description>
     </release>
     <release version="2.8" date="2024-03-20">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>The app features new adaptive widgets taking advantage of developments in GNOME 46</li>
         </ul>
       </description>
     </release>
     <release version="2.7" date="2023-12-12">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Flatpaks installed for the user and system-wide ones can now be imported separately</li>
         </ul>
       </description>
     </release>
     <release version="2.6" date="2023-10-11">
-      <description translatable="no">
+      <description translate="no">
         <p>You can now search your Cartridges library from GNOME!</p>
         <p>To enable the functionality, go to "Search" in the Settings app and toggle "Cartridges" on.</p>
       </description>
     </release>
     <release version="2.5" date="2023-10-06">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added the ability to refetch covers from SteamGridDB</li>
           <li>Fixed an issue with fractional scaling</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="2.4" date="2023-09-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Cartridges now adapts to smaller screen sizes</li>
           <li>You can now filter games by import source</li>
@@ -102,7 +102,7 @@
       </description>
     </release>
     <release version="2.3" date="2023-08-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>New import source: desktop entries</li>
           <li>Added the ability to pick executables via the file picker</li>
@@ -112,7 +112,7 @@
       </description>
     </release>
     <release version="2.2" date="2023-08-17">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>New import source: RetroArch</li>
           <li>Added the option to automatically remove uninstalled games on import</li>
@@ -123,7 +123,7 @@
       </description>
     </release>
     <release version="2.1" date="2023-07-25">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added support for Amazon Games in the Heroic importer</li>
           <li>Translations since 2.0</li>
@@ -131,7 +131,7 @@
       </description>
     </release>
     <release version="2.0" date="2023-07-05">
-      <description translatable="no">
+      <description translate="no">
         <p>After months of work, Cartridges 2.0 is here:</p>
         <ul>
           <li>New import source: Legendary</li>
@@ -145,7 +145,7 @@
       </description>
     </release>
     <release version="1.5" date="2023-05-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Cartridges is now part of GNOME Circle!</li>
           <li>Extra Steam libraries are now detected automatically</li>
@@ -156,7 +156,7 @@
       </description>
     </release>
     <release version="1.4" date="2023-04-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Support for animated covers</li>
           <li>Redesigned details view</li>
@@ -166,7 +166,7 @@
       </description>
     </release>
     <release version="1.3" date="2023-04-06">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Support for importing game covers from SteamGridDB!</li>
           <li>New import source: Lutris</li>
@@ -178,7 +178,7 @@
       </description>
     </release>
     <release version="1.2" date="2023-03-30">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Refined the user experience for importing games</li>
           <li>Added option to remove all games</li>
@@ -187,7 +187,7 @@
       </description>
     </release>
     <release version="1.1" date="2023-03-26">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added option to launch games by clicking the cover image</li>
           <li>Added option to save cover art losslessly</li>
@@ -196,7 +196,7 @@
       </description>
     </release>
     <release version="1.0" date="2023-03-25">
-      <description translatable="no">
+      <description translate="no">
         <p>First stable release</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

Please test your script or string extraction process before merging this PR.

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html