### PR TITLE
Fix lutris cover missing and steam non games imported

### DIFF
--- a/cartridges/preferences.py
+++ b/cartridges/preferences.py
@@ -1,6 +1,7 @@
 # preferences.py
 #
 # Copyright 2022-2023 kramo
+# Copyright 2024 Geoffrey Coulaud
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -66,6 +67,8 @@ class CartridgesPreferences(Adw.PreferencesDialog):
     lutris_expander_row = Gtk.Template.Child()
     lutris_data_action_row = Gtk.Template.Child()
     lutris_data_file_chooser_button = Gtk.Template.Child()
+    lutris_cache_action_row = Gtk.Template.Child()
+    lutris_cache_file_chooser_button = Gtk.Template.Child()
     lutris_import_steam_switch = Gtk.Template.Child()
     lutris_import_flatpak_switch = Gtk.Template.Child()
 

--- a/cartridges/store/managers/steam_api_manager.py
+++ b/cartridges/store/managers/steam_api_manager.py
@@ -1,6 +1,6 @@
 # steam_api_manager.py
 #
-# Copyright 2023 Geoffrey Coulaud
+# Copyright 2023-2024 Geoffrey Coulaud
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,8 +24,7 @@ from cartridges.game import Game
 from cartridges.store.managers.async_manager import AsyncManager
 from cartridges.utils.steam import (
     SteamAPIHelper,
-    SteamGameNotFoundError,
-    SteamNotAGameError,
+    SteamInvalidGameError,
     SteamRateLimiter,
 )
 
@@ -52,12 +51,7 @@ class SteamAPIManager(AsyncManager):
         # Get online metadata
         try:
             online_data = self.steam_api_helper.get_api_data(appid=appid)
-
-        except SteamGameNotFoundError:
-            return
-
-        except SteamNotAGameError:
+        except SteamInvalidGameError:
             game.update_values({"blacklisted": True})
-
         else:
             game.update_values(online_data)

--- a/cartridges/utils/steam.py
+++ b/cartridges/utils/steam.py
@@ -32,15 +32,24 @@ from cartridges.utils.rate_limiter import RateLimiter
 
 
 class SteamError(Exception):
-    pass
+    """Base Steam error"""
 
 
-class SteamGameNotFoundError(SteamError):
-    pass
+class SteamInvalidGameError(SteamError):
+    """Base class for cases where the Steam API informs that a game is invalid"""
 
 
-class SteamNotAGameError(SteamError):
-    pass
+class SteamGameNotFoundError(SteamInvalidGameError):
+    """
+    Error raised when a game is not found in the Steam API
+
+    This doesn't necessarily mean the appid doesn't exist, it may be a non-game appid.
+    For example, proton versions have an appid but are not games.
+    """
+
+
+class SteamNotAGameError(SteamInvalidGameError):
+    """Error raised when the appid is not a game"""
 
 
 class SteamInvalidManifestError(SteamError):

--- a/data/gtk/preferences.blp
+++ b/data/gtk/preferences.blp
@@ -177,6 +177,23 @@ template $CartridgesPreferences: Adw.PreferencesDialog {
           ]
         }
 
+        Adw.ActionRow lutris_cache_action_row {
+          title: _("Cache Location");
+
+          Button lutris_cache_file_chooser_button {
+            icon-name: "folder-symbolic";
+            valign: center;
+
+            styles [
+              "flat"
+            ]
+          }
+
+          styles [
+            "property"
+          ]
+        }
+
         Adw.SwitchRow lutris_import_steam_switch {
           title: _("Import Steam Games");
         }


### PR DESCRIPTION
## Fixed lutris cover import
- Added lutris cache location, since coverarts are stored there (at least in flatpak installations)
- Supporting `jpg` and `png` lutris covers

## Fixed Steam importing non games
- Now not importing games that get a `success: false` response from the Steam API.

Note that the API being unreachable means that all Steam games are imported, even Proton versions and runtimes.

---

It's been a while since I touched Cartridges' code!  
I want to change so many things... Ah well, bugfixes are a start :smile:  