### PR TITLE
chore: bump actions, image to G46, add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
+name: CI
 on:
   push:
     branches: [main]
   pull_request:
-name: CI
+
 concurrency:
   group: release-${{ github.sha }}
 jobs:
@@ -10,7 +11,7 @@ jobs:
     name: Flatpak
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-45
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
     - name: Checkout
@@ -53,7 +54,7 @@ jobs:
         run: iscc ".\_build\windows\Cartridges.iss"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer
           path: _build/windows/Output/Cartridges Setup.exe

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,12 @@
+name: Publish Release
 on:
   push:
     tags:
       "*"
-name: Publish Release
+
 concurrency:
   group: release-${{ github.sha }}
+
 jobs:
   publish-release:
     name: Publish Release
@@ -14,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v3.0.0
+        uses: dawidd6/action-download-artifact@v3.1.4
         with:
           workflow: ci.yml
           commit: ${{ github.sha }}
@@ -37,7 +39,7 @@ jobs:
         run: echo tag_name=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
 
       - name: Publish release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.5
         with:
           files: Windows Installer/Cartridges Setup.exe
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Changes

- Bump actions throughout the workflow files (Note: the bump to `actions/upload-artifact` will fix the warning currently shown under all runs).
- Add dependabot config to automatically check for GitHub action updates and create a PR for it monthly (if a new version exists).
- Set Flatpak container image version to GNOME 46.
- Minor refactoring of workflow parameters (with added spacing).