### PR TITLE
Revert "Improve UX for COSMIC"

### DIFF
--- a/cartridges/main.py
+++ b/cartridges/main.py
@@ -107,10 +107,6 @@ class CartridgesApplication(Adw.Application):
     def do_activate(self) -> None:  # pylint: disable=arguments-differ
         """Called on app creation"""
 
-        if os.getenv("XDG_CURRENT_DESKOP") == "COSMIC":
-            Gio.AppInfo.launch_default_for_uri("https://stopthemingmy.app")
-            self.quit()
-
         try:
             setup_logging()
         except ValueError:


### PR DESCRIPTION
This reverts commit 239420148a583c45d9df08de27be75cc537dc62b.

Please Stop Theming My App should be focused on distros or packagers theming the apps, shipping them broken, it's not user's fault as they don't know what is going on. popOS is one of the most used distros, and most of their users are new users that saw them in YouTube, please don't break their experience.