### PR TITLE
metainfo: Change `recommends` to `requires`

### DIFF
--- a/data/page.kramo.Cartridges.metainfo.xml.in
+++ b/data/page.kramo.Cartridges.metainfo.xml.in
@@ -31,9 +31,9 @@
     <control>keyboard</control>
     <control>touch</control>
   </supports>
-  <recommends>
+  <requires>
     <display_length compare="ge">360</display_length>
-  </recommends>
+  </requires>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/kra-mo/cartridges/main/data/screenshots/1.png</image>


### PR DESCRIPTION
Since Cartridges cannot physically scale below 360px, it should require at least that amount of space. Our [app overview infrastructure](https://sophie-h.pages.gitlab.gnome.org/app-overview/?annotations=true&last_review=true) has flagged the app with "No `<requires><display_length ...` specified", so this also serves to remove that.