### PR TITLE
Fix: Import never finishes

### DIFF
--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -104,9 +104,10 @@ class Importer(ErrorProducer):
     def add_source(self, source: Source) -> None:
         self.sources.add(source)
 
-    def __watchdog(self) -> bool:
+    def monitor_gui(self) -> bool:
         # TODO make this a dedicated GUI manager method that runs on main loop
         if not self.finished:
+            self.update_progressbar()
             return True
 
         # Clean up GUI once it's finished
@@ -122,12 +123,13 @@ class Importer(ErrorProducer):
 
         shared.win.get_application().lookup_action("import").set_enabled(False)
         shared.win.get_application().lookup_action("add_game").set_enabled(False)
+        shared.win.get_application().lookup_action("preferences").set_enabled(False)
 
         self.n_pipelines_done = 0
         self.n_source_tasks_done = 0
 
         self.create_dialog()
-        GLib.timeout_add(100, self.__watchdog)
+        GLib.timeout_add(100, self.monitor_gui)
 
         # Collect all errors and reset the cancellables for the managers
         # - Only one importer exists at any given time
@@ -223,11 +225,6 @@ class Importer(ErrorProducer):
                     "advanced",
                     self.pipeline_advanced_callback,
                 )
-                pipeline.connect(
-                    "advanced",
-                    # Update widget in main loop
-                    lambda *args: GLib.idle_add(self.update_progressbar),
-                )
                 self.game_pipelines.add(pipeline)
 
     def update_progressbar(self) -> None:
@@ -286,6 +283,7 @@ class Importer(ErrorProducer):
         self.create_error_dialog()
         shared.win.get_application().lookup_action("import").set_enabled(True)
         shared.win.get_application().lookup_action("add_game").set_enabled(True)
+        shared.win.get_application().lookup_action("preferences").set_enabled(True)
         shared.win.get_application().state = shared.AppState.DEFAULT
         shared.win.create_source_rows()
 

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -70,7 +70,6 @@ class Importer(ErrorProducer):
         self.game_pipelines = set()
         self.sources = set()
 
-
     """PUBLIC"""
 
     @property
@@ -261,12 +260,12 @@ class Importer(ErrorProducer):
         """Callback executed when a source is fully scanned"""
         source, *_rest = data
         logging.debug("Import done for source %s", source.source_id)
-        self.n_source_tasks_done += 1 # TODO is this threadsafe?
+        self.n_source_tasks_done += 1  # TODO is this threadsafe?
 
     def pipeline_advanced_callback(self, pipeline: Pipeline) -> None:
         """Callback called when a pipeline for a game has advanced"""
         if pipeline.is_done:
-            self.n_pipelines_done += 1 # TODO is this threadsafe?
+            self.n_pipelines_done += 1  # TODO is this threadsafe?
 
     """GUI Actions"""
 

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -246,7 +246,6 @@ class Importer(ErrorProducer):
                 continue
 
             # Register game
-            # TODO investigate this
             pipeline: Pipeline = shared.store.add_game(game, additional_data)
             if pipeline is not None:
                 logging.info("Imported %s (%s)", game.name, game.game_id)
@@ -260,12 +259,12 @@ class Importer(ErrorProducer):
         """Callback executed when a source is fully scanned"""
         source, *_rest = data
         logging.debug("Import done for source %s", source.source_id)
-        self.n_source_tasks_done += 1  # TODO is this threadsafe?
+        self.n_source_tasks_done += 1
 
     def pipeline_advanced_callback(self, pipeline: Pipeline) -> None:
         """Callback called when a pipeline for a game has advanced"""
         if pipeline.is_done:
-            self.n_pipelines_done += 1  # TODO is this threadsafe?
+            self.n_pipelines_done += 1
 
     """GUI Actions"""
 

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -209,8 +209,12 @@ class Importer(ErrorProducer):
                 logging.info("Imported %s (%s)", game.name, game.game_id)
                 pipeline.connect(
                     "advanced",
-                    # I'm not sure idle_add is needed here, but a widget is updated in the callback
-                    lambda *args: GLib.idle_add(self.pipeline_advanced_callback, *args),
+                    self.pipeline_advanced_callback,
+                )
+                pipeline.connect(
+                    "advanced",
+                    # Update widget in main loop
+                    lambda *args: GLib.idle_add(self.update_progressbar),
                 )
                 self.game_pipelines.add(pipeline)
 
@@ -243,7 +247,6 @@ class Importer(ErrorProducer):
         * A source finishes
         * A pipeline finishes
         """
-        self.update_progressbar()
         if self.finished:
             self.import_callback()
 

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -33,6 +33,7 @@ from cartridges.importer.source import Source
 from cartridges.store.managers.async_manager import AsyncManager
 from cartridges.store.pipeline import Pipeline
 
+
 # pylint: disable=too-many-instance-attributes
 class Importer(ErrorProducer):
     """A class in charge of scanning sources for games"""
@@ -379,11 +380,15 @@ class Importer(ErrorProducer):
 
         elif self.n_games_added >= 1:
             # The variable is the number of games.
-            toast_title = ngettext("{} game imported", "{} games imported", self.n_games_added).format(self.n_games_added)
+            toast_title = ngettext(
+                "{} game imported", "{} games imported", self.n_games_added
+            ).format(self.n_games_added)
 
         if (removed_length := len(self.removed_game_ids)) >= 1:
             # The variable is the number of games. This text comes after "{0} games imported".
-            toast_title += ngettext(", {} removed", ", {} removed", removed_length).format(removed_length)
+            toast_title += ngettext(
+                ", {} removed", ", {} removed", removed_length
+            ).format(removed_length)
 
         if self.n_games_added or self.removed_game_ids:
             toast.set_button_label(_("Undo"))


### PR DESCRIPTION
Fixes #270

This is caused by a race condition in the importer class. `GLib.idle_add` calls the `pipeline_advanced_callback` too often, so the `n_pipelines_done` counter becomes greater than the total game pipelines. This usually isn't a factor because the source tasks usually finish before the pipelines, but when they don't, the importer can never be "finished" importing. So importing is permanently stalled even though all the work was successful.

From my testing, this fixes the issue and doesn't seem to break anything else. But I don't really understand the comment which says it updates a widget. What widget? It doesn't seem to have a clear effect on the progress bar.