### PR TITLE
Move to `ngettext`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build-aux/flatpak/page.kramo.Cartridges.json
 /subprojects/blueprint-compiler
 /build-aux/macos/build
 /build-aux/macos/dist

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -18,6 +18,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import gettext
 import logging
 from time import time
 from typing import Any, Optional
@@ -32,7 +33,6 @@ from cartridges.importer.location import UnresolvableLocationError
 from cartridges.importer.source import Source
 from cartridges.store.managers.async_manager import AsyncManager
 from cartridges.store.pipeline import Pipeline
-
 
 # pylint: disable=too-many-instance-attributes
 class Importer(ErrorProducer):
@@ -376,20 +376,13 @@ class Importer(ErrorProducer):
                     "import",
                 )
 
-        elif self.n_games_added == 1:
-            toast_title = _("1 game imported")
+        elif self.n_games_added >= 1:
+            # The variable is the number of games imported
+            toast_title = gettext.ngettext("1 game imported", "{} games imported", self.n_games_added).format(self.n_games_added)
 
-        elif self.n_games_added > 1:
-            # The variable is the number of games
-            toast_title = _("{} games imported").format(self.n_games_added)
-
-        if (removed_length := len(self.removed_game_ids)) == 1:
-            # A single game removed
-            toast_title += ", " + _("1 removed")
-
-        elif removed_length > 1:
+        if (removed_length := len(self.removed_game_ids)) >= 1:
             # The variable is the number of games removed
-            toast_title += ", " + _("{} removed").format(removed_length)
+            toast_title += ", " + gettext.ngettext("1 removed", "{} removed", removed_length).format(removed_length)
 
         if self.n_games_added or self.removed_game_ids:
             toast.set_button_label(_("Undo"))

--- a/cartridges/importer/importer.py
+++ b/cartridges/importer/importer.py
@@ -377,11 +377,11 @@ class Importer(ErrorProducer):
 
         elif self.n_games_added >= 1:
             # The variable is the number of games imported
-            toast_title = gettext.ngettext("1 game imported", "{} games imported", self.n_games_added).format(self.n_games_added)
+            toast_title = gettext.ngettext("{} game imported", "{} games imported", self.n_games_added).format(self.n_games_added)
 
         if (removed_length := len(self.removed_game_ids)) >= 1:
-            # The variable is the number of games removed
-            toast_title += ", " + gettext.ngettext("1 removed", "{} removed", removed_length).format(removed_length)
+            # The variable is the number of games removed. This comes after the text "{} games imported, ".
+            toast_title += ", " + gettext.ngettext("{} removed", "{} removed", removed_length).format(removed_length)
 
         if self.n_games_added or self.removed_game_ids:
             toast.set_button_label(_("Undo"))

--- a/cartridges/main.py
+++ b/cartridges/main.py
@@ -288,7 +288,7 @@ class CartridgesApplication(Adw.Application):
         about.set_designers(("kramo https://kramo.page",))
         about.set_copyright("© 2022-2024 kramo")
         # Translators: Replace this with your name for it to show up in the about window
-        about.set_translator_credits = (_("translator_credits"),)
+        about.set_translator_credits = (_("translator-credits"),)
         about.set_debug_info(debug_str)
         about.set_debug_info_filename("cartridges.log")
         about.add_legal_section(

--- a/cartridges/main.py
+++ b/cartridges/main.py
@@ -287,8 +287,8 @@ class CartridgesApplication(Adw.Application):
         )
         about.set_designers(("kramo https://kramo.page",))
         about.set_copyright("© 2022-2024 kramo")
-        # Translators: Replace this with your name for it to show up in the about window
-        about.set_translator_credits = (_("translator-credits"),)
+        # Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
+        about.set_translator_credits(_("translator-credits"))
         about.set_debug_info(debug_str)
         about.set_debug_info_filename("cartridges.log")
         about.add_legal_section(

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -15,6 +15,7 @@ cartridges/game.py
 cartridges/preferences.py
 
 cartridges/utils/create_dialog.py
+cartridges/utils/relative_date.py
 
 cartridges/importer/importer.py
 cartridges/importer/source.py

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Ali-98 <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/cartridges/"
@@ -539,9 +539,17 @@ msgid "{} unhidden"
 msgstr "أٌظهرت {}"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "أزيلت {}"
+msgid_plural "{} removed"
+msgstr[0] "أزيلت {}"
+msgstr[1] "أزيلت {}"
+msgstr[2] "أزيلت {}"
+msgstr[3] "أزيلت {}"
+msgstr[4] "أزيلت {}"
+msgstr[5] "أزيلت {}"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -585,6 +593,32 @@ msgstr "عيِّن الموضع"
 msgid "Dismiss"
 msgstr "تجاهل"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "اليوم"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "أمس"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "لُعبت آخر مرَّة"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "لُعبت آخر مرَّة"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "تُستورد الألعاب…"
@@ -600,26 +634,14 @@ msgstr "لم يُعثر على ألعاب جديدة"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "اُستوردت لعبة واحدة"
+msgstr[0] "اُستوردت {} لعبة"
 msgstr[1] "اُستوردت {} لعبة"
 msgstr[2] "اُستوردت {} لعبة"
 msgstr[3] "اُستوردت {} لعبة"
 msgstr[4] "اُستوردت {} لعبة"
 msgstr[5] "اُستوردت {} لعبة"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "أزيل ١"
-msgstr[1] "أزيل {}"
-msgstr[2] "أزيل {}"
-msgstr[3] "أزيل {}"
-msgstr[4] "أزيل {}"
-msgstr[5] "أزيل {}"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -657,8 +679,25 @@ msgstr "تعذَّر استيثاق SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "أكِّد مفتاح واجهة البرمجة في التفضيلات"
 
-#~ msgid "{} games imported"
-#~ msgstr "اُستوردت {} لعبة"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "اُستوردت لعبة واحدة"
+#~ msgstr[1] "اُستوردت {} لعبة"
+#~ msgstr[2] "اُستوردت {} لعبة"
+#~ msgstr[3] "اُستوردت {} لعبة"
+#~ msgstr[4] "اُستوردت {} لعبة"
+#~ msgstr[5] "اُستوردت {} لعبة"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "أزيل ١"
+#~ msgstr[1] "أزيل {}"
+#~ msgstr[2] "أزيل {}"
+#~ msgstr[3] "أزيل {}"
+#~ msgstr[4] "أزيل {}"
+#~ msgstr[5] "أزيل {}"
 
 #~ msgid "Cache Location"
 #~ msgstr "موضع الذاكرة المؤقتة"
@@ -723,12 +762,6 @@ msgstr "أكِّد مفتاح واجهة البرمجة في التفضيلات"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "موضع تثبيت قوارير"
-
-#~ msgid "Today"
-#~ msgstr "اليوم"
-
-#~ msgid "Yesterday"
-#~ msgstr "أمس"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "لم يُعثر على الذاكرة المؤقَّتة"

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Ali-98 <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/cartridges/"
@@ -436,9 +436,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "بُدئت {}"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Ali Aljishi <ahj696@hotmail.com>"
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Ali-98 <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "وبرامج أخرى، وذلك دون تسجيل دخول. ولك ترتيب وإخفاء الألعاب فيه كيفما شئت، "
 "وكذلك تستطيع منه تنزيل غُلُف الألعاب من SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "تفاصيل اللعبة"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "حرِّر تفاصيل اللعبة"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "التفضيلات"
 
@@ -73,47 +73,47 @@ msgstr "التفضيلات"
 msgid "Cancel"
 msgstr "ألغِ"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "غلاف جديد"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "احذف الغلاف"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "العنوان"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "المطوِّر (اختياري)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "ملفُّ التنفيذ"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "اختر ملفًّا"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "معلومات أكثر"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "حرِّر"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "أخفِ"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "أزل"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "اكشف"
 
@@ -121,17 +121,17 @@ msgstr "اكشف"
 msgid "General"
 msgstr "عام"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "ابحث"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "اختصارات لوحة المفاتيح"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "تراجع"
 
@@ -139,11 +139,11 @@ msgstr "تراجع"
 msgid "Quit"
 msgstr "أنهِ"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "أظهر شريط الجانب"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "القائمة الرئيسة"
 
@@ -151,12 +151,12 @@ msgstr "القائمة الرئيسة"
 msgid "Games"
 msgstr "الألعاب"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "أضف لعبةً"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "استورد"
 
@@ -168,8 +168,8 @@ msgstr "أظهر الألعاب المخفية"
 msgid "Remove Game"
 msgstr "أزل اللعبة"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "السلوك"
 
@@ -185,7 +185,7 @@ msgstr "تبدأ صورة الغلاف اللعبة"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "يبدِّل سلوك صورة الغلاف وزرِّ «العب»"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "الصور"
 
@@ -201,137 +201,141 @@ msgstr "احفظ غُلُف الألعاب دون فقد على حساب مسا�
 msgid "Danger Zone"
 msgstr "منطقة خطر"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "أزل كلَّ الألعاب"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "أزل الألعاب المحذوفة"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "المصادر"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "ستيم"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "موضع التثبيت"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "لوترس"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "استورد ألعابًا من ستيم"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "استورد ألعاب فلاتباك"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "هِرُوِك"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "استورد ألعاب أَبِك"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "استورد ألعاب جي‌أو‌جي"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "استورد ألعابًا من أمازون"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "استورد ألعابًا مثبَّتةً بغير متجر"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "قوارير"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "إتش"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "لجندري"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "رتروآرتش"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "فلاتباك"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "موضع النظام"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "موضع المستخدم"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "استورد مشغِّلات ألعاب"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "مدخلات سطح المكتب"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "الاستيثاق"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "مفتاح واجهة البرمجة"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "استخدم SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "نزِّل الصور حينما تنزِّل أو تستورد الألعاب"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "فضِّلها على الصور الرسمية"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "فضِّل الصور المتحرِّكة"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "حدِّث الغُلُف"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "اجلب غُلُفًا للألعاب التي في المكتبة"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "حدِّث"
 
@@ -359,135 +363,136 @@ msgstr "لا توجد ألعاب مخفية"
 msgid "Games you hide will appear here"
 msgstr "هنا يظهر ما أخفيت من ألعاب"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "كلُّ الألعاب"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "أُضيفَت"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "اُستوردَت"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "الألعاب المخفية"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "عنوان اللعبة"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "العب"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "رتِّب"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "أ-ي"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "ي-أ"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "الأجدد"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "الأقدم"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "لُعبت آخر مرَّة"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "أظهر ما أخفي"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "عن «خراطيش»"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "بُدئت {}"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Ali Aljishi <ahj696@hotmail.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "أضيفت في: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "أبدًا"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "لُعبت آخر مرَّة في: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "طبِّق"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "أضف لعبةً جديدةً"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "أضف"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "ملفات التنفيذ"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "ملف.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "البرنامج"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\المسار\\إلى\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/المسار/إلى/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -509,19 +514,19 @@ msgstr ""
 "\n"
 "ولا تنسَ إحاطة المسار بعلامتي تنصيص مزدوجتين حالما تضمَّن مسافات!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "تعذَّرت إضافة اللعبة"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "لا يجوز كون عنوان اللعبة فارغًا."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "لا يجوز كون ملفِّ التنفيذ فارغًا."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "تعذَّر تطبيق التفضيلات"
 
@@ -535,50 +540,49 @@ msgid "{} unhidden"
 msgstr "أٌظهرت {}"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "أزيلت {}"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "أُزيلت كلُّ الألعاب"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "تحتاج مفتاح واجهة برمجة حال ما أردت استخدام SteamGridDB، {}هنا تولِّده{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "تُنزَّل الغُلُف…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "حُدِّثت الغُلُف"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "لم يُعثر على التثبيت"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "حدِّد مجلَّدًا صالحًا"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "تحذير"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "مجلَّد غير صالح"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "عيِّن الموضع"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "تجاهل"
 
@@ -586,27 +590,37 @@ msgstr "تجاهل"
 msgid "Importing Games…"
 msgstr "تُستورد الألعاب…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "طرأ هذا الخطأ أثناء الاستيراد:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "لم يُعثر على ألعاب جديدة"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "اُستوردت لعبة واحدة"
+msgid_plural "{} games imported"
+msgstr[0] "اُستوردت لعبة واحدة"
+msgstr[1] "اُستوردت {} لعبة"
+msgstr[2] "اُستوردت {} لعبة"
+msgstr[3] "اُستوردت {} لعبة"
+msgstr[4] "اُستوردت {} لعبة"
+msgstr[5] "اُستوردت {} لعبة"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "اُستوردت {} لعبة"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "أزيل ١"
+msgid_plural "{} removed"
+msgstr[0] "أزيل ١"
+msgstr[1] "أزيل {}"
+msgstr[2] "أزيل {}"
+msgstr[3] "أزيل {}"
+msgstr[4] "أزيل {}"
+msgstr[5] "أزيل {}"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -643,6 +657,9 @@ msgstr "تعذَّر استيثاق SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "أكِّد مفتاح واجهة البرمجة في التفضيلات"
+
+#~ msgid "{} games imported"
+#~ msgstr "اُستوردت {} لعبة"
 
 #~ msgid "Cache Location"
 #~ msgstr "موضع الذاكرة المؤقتة"

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Ali-98 <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "حرِّر تفاصيل اللعبة"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "التفضيلات"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "اختصارات لوحة المفاتيح"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "تراجع"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "أزل اللعبة"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "السلوك"
 
@@ -205,137 +205,137 @@ msgstr "منطقة خطر"
 msgid "Remove All Games"
 msgstr "أزل كلَّ الألعاب"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "أزل الألعاب المحذوفة"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "المصادر"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "ستيم"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "موضع التثبيت"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "لوترس"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "استورد ألعابًا من ستيم"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "استورد ألعاب فلاتباك"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "هِرُوِك"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "استورد ألعاب أَبِك"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "استورد ألعاب جي‌أو‌جي"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "استورد ألعابًا من أمازون"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "استورد ألعابًا مثبَّتةً بغير متجر"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "قوارير"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "إتش"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "لجندري"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "رتروآرتش"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "فلاتباك"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "موضع النظام"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "موضع المستخدم"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "استورد مشغِّلات ألعاب"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "مدخلات سطح المكتب"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "الاستيثاق"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "مفتاح واجهة البرمجة"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "استخدم SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "نزِّل الصور حينما تنزِّل أو تستورد الألعاب"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "فضِّلها على الصور الرسمية"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "فضِّل الصور المتحرِّكة"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "حدِّث الغُلُف"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "اجلب غُلُفًا للألعاب التي في المكتبة"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "حدِّث"
 
@@ -543,45 +543,45 @@ msgstr "أٌظهرت {}"
 msgid "{} removed"
 msgstr "أزيلت {}"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "أُزيلت كلُّ الألعاب"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "تحتاج مفتاح واجهة برمجة حال ما أردت استخدام SteamGridDB، {}هنا تولِّده{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "تُنزَّل الغُلُف…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "حُدِّثت الغُلُف"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "لم يُعثر على التثبيت"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "حدِّد مجلَّدًا صالحًا"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "تحذير"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "مجلَّد غير صالح"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "عيِّن الموضع"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "تجاهل"
 
@@ -589,16 +589,16 @@ msgstr "تجاهل"
 msgid "Importing Games…"
 msgstr "تُستورد الألعاب…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "طرأ هذا الخطأ أثناء الاستيراد:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "لم يُعثر على ألعاب جديدة"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[4] "اُستوردت {} لعبة"
 msgstr[5] "اُستوردت {} لعبة"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/be.po
+++ b/po/be.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-13 09:28+0000\n"
 "Last-Translator: Yahor <k1llo2810@protonmail.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/cartridges/"
@@ -56,8 +56,8 @@ msgstr ""
 "ўваходу ў сістэму. Вы можаце сартаваць і хаваць гульні або спампоўваць "
 "вокладку з SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Падрабязнасці аб гульні"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Рэдагаваць падрабязнасці аб гульні"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -75,47 +75,47 @@ msgstr "Параметры"
 msgid "Cancel"
 msgstr "Скасаваць"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Новая вокладка"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Выдалиць вокладку"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Назва"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Распрацоўшчык (неабавязкова)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Выконваны"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Выбраць файл"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Больш інфармацыі"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Рэдагаваць"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Схаваць"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Выдаліць"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Паказаць"
 
@@ -123,17 +123,17 @@ msgstr "Паказаць"
 msgid "General"
 msgstr "Агульнае"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Пошук"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Спалучэнні клавіш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Адмяніць"
 
@@ -141,11 +141,11 @@ msgstr "Адмяніць"
 msgid "Quit"
 msgstr "Выйсці"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Пераключыць бакавую панэль"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Галоўнае меню"
 
@@ -153,12 +153,12 @@ msgstr "Галоўнае меню"
 msgid "Games"
 msgstr "Гульні"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Дадаць гульню"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Імпарт"
 
@@ -170,8 +170,8 @@ msgstr "Паказаць схаваныя гульні"
 msgid "Remove Game"
 msgstr "Выдаліць гульню"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Паводзіны"
 
@@ -187,7 +187,7 @@ msgstr "Выява вокладкі запускае гульню"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Мяняе паводзіны вокладкі і кнопкі запуску"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Відарысы"
 
@@ -203,137 +203,141 @@ msgstr "Захаванне вокладак гульняў без страт з�
 msgid "Danger Zone"
 msgstr "Небяспечная зона"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Выдаліць усе гульні"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Выдаляць дэінсталяваныя гульні"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Крыніцы"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Месца ўсталёўкі"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Імпарт гульняў Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Імпарт гульняў Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Імпарт Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Імпарт гульняў GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Імпарт гульняў Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Імпарт іншых гульняў"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Сістэмнае размяшчэнне"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Карыстальніцкае размяшчэнне"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Імпарт сродкаў запуску гульняў"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Запісы працоўнага стала"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Аўтэнтыфікацыя"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Ключ API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Выкарыстоўвайць SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Спампоўка відарысаў пры даданні ці імпарце гульняў"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Аддавайце перавагу афіцыйным відарысам"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Аддавайце перавагу аніміраваным відарысам"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Абнавіць вокладкі"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Атрымаць вокладкі для гульняў, якія ўжо ёсць у вашай бібліятэцы"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Абнавіць"
 
@@ -361,135 +365,136 @@ msgstr "Няма схаваных гульняў"
 msgid "Games you hide will appear here"
 msgstr "Гульні, якія вы схаваеце, з'явяцца тут"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Усе гульні"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Дададзена"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Імпартавана"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Схаваныя гульні"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Назва гульні"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Гуляць"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Сартаваць"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "А-Я"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Я-А"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Найноўшыя"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Старэйшыя"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Апошняя гульня"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Паказаць схаваныя"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Аб картрыджах"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} запушчана"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Yahor Haurylenka https://github.com/k1llo"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Дададзена: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Ніколі"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Гулялі апошні раз: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Ужыць"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Дадаць новую гульню"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Дадаць"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Выконваныя"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "праграма"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\шлях\\да\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/шлях/да/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -511,19 +516,19 @@ msgstr ""
 "\n"
 "Калі шлях змяшчае прабелы, абавязкова заключыце яго ў падвойныя двукоссі!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Не ўдалося дадаць гульню"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Назва гульні не можа быць пустой."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Выканальны файл не можа быць пустым."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Не ўдалося прымяніць параметры"
 
@@ -537,51 +542,50 @@ msgid "{} unhidden"
 msgstr "{} непрыхавана"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} выдалена"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Усе гульні выдалены"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для выкарыстання SteamGridDB патрабуецца ключ API. Вы можаце стварыць яго {}"
 "тут{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Спампоўка вокладак…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Вокладкі абноўлены"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Усталяванне не знойдзена"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Выберыце сапраўдны каталог"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Увага"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Няправільны каталог"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Задаць размяшчэнне"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Адхіліць"
 
@@ -589,27 +593,31 @@ msgstr "Адхіліць"
 msgid "Importing Games…"
 msgstr "Імпарт гульняў…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Падчас імпарту адбыліся наступныя памылкі:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Новыя гульні не знойдзены"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "Імпартавана 1 гульня"
+msgid_plural "{} games imported"
+msgstr[0] "Імпартавана 1 гульня"
+msgstr[1] "Імпартавана {} гульня"
+msgstr[2] "Імпартавана {} гульня"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} гульняў імпартавана"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 выдалена"
+msgid_plural "{} removed"
+msgstr[0] "1 выдалена"
+msgstr[1] "{} выдалена"
+msgstr[2] "{} выдалена"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -646,6 +654,9 @@ msgstr "Немагчыма аўтэнтыфікаваць SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Праверце свой ключ API ў наладах"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} гульняў імпартавана"
 
 #~ msgid "Cache Location"
 #~ msgstr "Размяшчэнне кэша"

--- a/po/be.po
+++ b/po/be.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-13 09:28+0000\n"
 "Last-Translator: Yahor <k1llo2810@protonmail.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/cartridges/"
@@ -438,9 +438,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} запушчана"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Yahor Haurylenka https://github.com/k1llo"
 

--- a/po/be.po
+++ b/po/be.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-13 09:28+0000\n"
 "Last-Translator: Yahor <k1llo2810@protonmail.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/cartridges/"
@@ -541,9 +541,14 @@ msgid "{} unhidden"
 msgstr "{} непрыхавана"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} выдалена"
+msgid_plural "{} removed"
+msgstr[0] "{} выдалена"
+msgstr[1] "{} выдалена"
+msgstr[2] "{} выдалена"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -588,6 +593,32 @@ msgstr "Задаць размяшчэнне"
 msgid "Dismiss"
 msgstr "Адхіліць"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Апошняя гульня"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Апошняя гульня"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Імпарт гульняў…"
@@ -603,20 +634,11 @@ msgstr "Новыя гульні не знойдзены"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "Імпартавана 1 гульня"
-msgstr[1] "Імпартавана {} гульня"
-msgstr[2] "Імпартавана {} гульня"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 выдалена"
-msgstr[1] "{} выдалена"
-msgstr[2] "{} выдалена"
+msgstr[0] "{} гульняў імпартавана"
+msgstr[1] "{} гульняў імпартавана"
+msgstr[2] "{} гульняў імпартавана"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -654,8 +676,19 @@ msgstr "Немагчыма аўтэнтыфікаваць SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Праверце свой ключ API ў наладах"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} гульняў імпартавана"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "Імпартавана 1 гульня"
+#~ msgstr[1] "Імпартавана {} гульня"
+#~ msgstr[2] "Імпартавана {} гульня"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 выдалена"
+#~ msgstr[1] "{} выдалена"
+#~ msgstr[2] "{} выдалена"
 
 #~ msgid "Cache Location"
 #~ msgstr "Размяшчэнне кэша"

--- a/po/be.po
+++ b/po/be.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-13 09:28+0000\n"
 "Last-Translator: Yahor <k1llo2810@protonmail.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/cartridges/"
@@ -67,7 +67,7 @@ msgstr "Рэдагаваць падрабязнасці аб гульні"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Спалучэнні клавіш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Адмяніць"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Выдаліць гульню"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Паводзіны"
 
@@ -207,137 +207,137 @@ msgstr "Небяспечная зона"
 msgid "Remove All Games"
 msgstr "Выдаліць усе гульні"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Выдаляць дэінсталяваныя гульні"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Крыніцы"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Месца ўсталёўкі"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Імпарт гульняў Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Імпарт гульняў Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Імпарт Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Імпарт гульняў GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Імпарт гульняў Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Імпарт іншых гульняў"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Сістэмнае размяшчэнне"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Карыстальніцкае размяшчэнне"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Імпарт сродкаў запуску гульняў"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Запісы працоўнага стала"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Аўтэнтыфікацыя"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Ключ API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Выкарыстоўвайць SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Спампоўка відарысаў пры даданні ці імпарце гульняў"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Аддавайце перавагу афіцыйным відарысам"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Аддавайце перавагу аніміраваным відарысам"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Абнавіць вокладкі"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Атрымаць вокладкі для гульняў, якія ўжо ёсць у вашай бібліятэцы"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Абнавіць"
 
@@ -545,46 +545,46 @@ msgstr "{} непрыхавана"
 msgid "{} removed"
 msgstr "{} выдалена"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Усе гульні выдалены"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для выкарыстання SteamGridDB патрабуецца ключ API. Вы можаце стварыць яго {}"
 "тут{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Спампоўка вокладак…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Вокладкі абноўлены"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Усталяванне не знойдзена"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Выберыце сапраўдны каталог"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Увага"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Няправільны каталог"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Задаць размяшчэнне"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Адхіліць"
 
@@ -592,16 +592,16 @@ msgstr "Адхіліць"
 msgid "Importing Games…"
 msgstr "Імпарт гульняў…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Падчас імпарту адбыліся наступныя памылкі:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Новыя гульні не знойдзены"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[1] "Імпартавана {} гульня"
 msgstr[2] "Імпартавана {} гульня"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: jolupa <jolupameister@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartridges/"
@@ -63,7 +63,7 @@ msgstr "Editar els detalls del joc"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferències"
 
@@ -129,7 +129,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Dreceres de teclat"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Desfés"
 
@@ -167,7 +167,7 @@ msgid "Remove Game"
 msgstr "Eliminar joc"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportament"
 
@@ -203,137 +203,137 @@ msgstr "Zona de perill"
 msgid "Remove All Games"
 msgstr "Esborrar tots els jocs"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Esborrar jocs desinstal·lats"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Fonts"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Ubicació de la instal·lació"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importar jocs de Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importar jocs de Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importar jocs de Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importar jocs de GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importar jocs de Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importar jocs no aprovats"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Ubicació del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Ubicació de l'usuari"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importar llançadors de jocs"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entrades d'escriptori"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autenticació"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Clau API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Fes servir SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Descarregar les imatges al afegir o importar jocs"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Prefereix sobre imatges oficials"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Prefereix imatges animades"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Actualitzar cobertes"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Descarregar cobertes per a jocs que ja es troben a la teva llibreria"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Actualitzar"
 
@@ -541,46 +541,46 @@ msgstr "{} mostrar"
 msgid "{} removed"
 msgstr "{} eliminat"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Tots els jocs eliminats"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Es necessita una clau API per poder fer servir SteamGridDB. Pots generar una "
 "{}aquí{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Descarregant cobertes…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Cobertes actualitzades"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "No s'ha trobat l'instal·lacióó"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Selecciona un directori vàlid"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Avis"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Directori no vàlid"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Escull una ubicació"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -588,16 +588,16 @@ msgstr "Descartar"
 msgid "Importing Games…"
 msgstr "Important jocs…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Han succeït els següents errors al importar:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "No s'han trobat jocs nous"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -605,7 +605,7 @@ msgstr[0] "1 joc importat"
 msgstr[1] "{} jocs importats"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: jolupa <jolupameister@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartridges/"
@@ -537,9 +537,13 @@ msgid "{} unhidden"
 msgstr "{} mostrar"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} eliminat"
+msgid_plural "{} removed"
+msgstr[0] "{} eliminat"
+msgstr[1] "{} eliminat"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -584,6 +588,32 @@ msgstr "Escull una ubicació"
 msgid "Dismiss"
 msgstr "Descartar"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Últim jugat"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Últim jugat"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Important jocs…"
@@ -599,18 +629,10 @@ msgstr "No s'han trobat jocs nous"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 joc importat"
+msgstr[0] "{} jocs importats"
 msgstr[1] "{} jocs importats"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 eliminat"
-msgstr[1] "{} eliminats"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -648,8 +670,17 @@ msgstr "No es pot Autenticar a SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifica la teva clau API en les preferències"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} jocs importats"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 joc importat"
+#~ msgstr[1] "{} jocs importats"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 eliminat"
+#~ msgstr[1] "{} eliminats"
 
 #~ msgid "Cache Location"
 #~ msgstr "Ubicació de la memòria cau"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: jolupa <jolupameister@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartridges/"
@@ -434,11 +434,10 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} llançat"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
-msgstr "crèdits_traductors"
+msgstr "jolupa <jolupameister@gmail.com>"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: jolupa <jolupameister@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartridges/"
@@ -52,8 +52,8 @@ msgstr ""
 "necessitat de iniciar sessió. Pots ordenar i amagar els jocs o descarregar "
 "l'art de la coberta de SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalls del joc"
 
@@ -62,8 +62,8 @@ msgid "Edit Game Details"
 msgstr "Editar els detalls del joc"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferències"
 
@@ -71,47 +71,47 @@ msgstr "Preferències"
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Coberta nova"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Eliminar la coberta"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Títol"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Desenvolupador (opcional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Executable"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Seleccionar fitxer"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Més informació"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Editar"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Amagar"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Esborrar"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Mostrar"
 
@@ -119,17 +119,17 @@ msgstr "Mostrar"
 msgid "General"
 msgstr "General"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Cercar"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Dreceres de teclat"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Desfés"
 
@@ -137,11 +137,11 @@ msgstr "Desfés"
 msgid "Quit"
 msgstr "Sortir"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Alternar la barra lateral"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menú principal"
 
@@ -149,12 +149,12 @@ msgstr "Menú principal"
 msgid "Games"
 msgstr "Jocs"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Afegeix joc"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importar"
 
@@ -166,8 +166,8 @@ msgstr "Mostrar jocs ocults"
 msgid "Remove Game"
 msgstr "Eliminar joc"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportament"
 
@@ -183,7 +183,7 @@ msgstr "La imatge de la coberta llança el joc"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Canvia el comportament de la imatge de la coberta i el botó de jugar"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Imatges"
 
@@ -199,137 +199,141 @@ msgstr "Guarda les cobertes del joc sense pèrdues amb el cost d'emmagatzematge"
 msgid "Danger Zone"
 msgstr "Zona de perill"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Esborrar tots els jocs"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Esborrar jocs desinstal·lats"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Fonts"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Ubicació de la instal·lació"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importar jocs de Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importar jocs de Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importar jocs de Epic"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importar jocs de GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importar jocs de Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importar jocs no aprovats"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Ubicació del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Ubicació de l'usuari"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importar llançadors de jocs"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entrades d'escriptori"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autenticació"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Clau API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Fes servir SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Descarregar les imatges al afegir o importar jocs"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Prefereix sobre imatges oficials"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Prefereix imatges animades"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Actualitzar cobertes"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Descarregar cobertes per a jocs que ja es troben a la teva llibreria"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Actualitzar"
 
@@ -357,135 +361,136 @@ msgstr "No hi han jocs amagats"
 msgid "Games you hide will appear here"
 msgstr "Els jocs que amaguis sortiran aquí"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Tots els jocs"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Afegit"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importat"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Jocs amagats"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Títol del joc"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Jugar"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordenar"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Més recent"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Més antic"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Últim jugat"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Mostrar els amagats"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Sobre Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} llançat"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "crèdits_traductors"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Afegit: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Mai"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Últim jugat: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Aplicar"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Afegeix joc nou"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Afegir"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Executables"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "fitxer.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programa"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\camí\\a\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/camí/a/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -507,19 +512,19 @@ msgstr ""
 "\n"
 "Si el camí conté espais, assegurat d'envoltar-lo amb cometes dobles!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "No es pot afegir el joc"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "El títol del joc no pot estar buit."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "El executable no pot estar buit."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "No s'han pogut aplicar les preferències"
 
@@ -533,51 +538,50 @@ msgid "{} unhidden"
 msgstr "{} mostrar"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} eliminat"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Tots els jocs eliminats"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Es necessita una clau API per poder fer servir SteamGridDB. Pots generar una "
 "{}aquí{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Descarregant cobertes…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Cobertes actualitzades"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "No s'ha trobat l'instal·lacióó"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Selecciona un directori vàlid"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Avis"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Directori no vàlid"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Escull una ubicació"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -585,27 +589,29 @@ msgstr "Descartar"
 msgid "Importing Games…"
 msgstr "Important jocs…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Han succeït els següents errors al importar:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "No s'han trobat jocs nous"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 joc importat"
+msgid_plural "{} games imported"
+msgstr[0] "1 joc importat"
+msgstr[1] "{} jocs importats"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} jocs importats"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 eliminat"
+msgid_plural "{} removed"
+msgstr[0] "1 eliminat"
+msgstr[1] "{} eliminats"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -642,6 +648,9 @@ msgstr "No es pot Autenticar a SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifica la teva clau API en les preferències"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} jocs importats"
 
 #~ msgid "Cache Location"
 #~ msgstr "Ubicació de la memòria cau"

--- a/po/cartridges.pot
+++ b/po/cartridges.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: data/page.kramo.Cartridges.desktop.in:3
 #: data/page.kramo.Cartridges.metainfo.xml.in:9
@@ -46,8 +47,8 @@ msgid ""
 "SteamGridDB."
 msgstr ""
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr ""
 
@@ -56,8 +57,8 @@ msgid "Edit Game Details"
 msgstr ""
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr ""
 
@@ -65,47 +66,47 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr ""
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr ""
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr ""
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr ""
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr ""
 
@@ -113,17 +114,17 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr ""
 
@@ -131,11 +132,11 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr ""
 
@@ -143,12 +144,12 @@ msgstr ""
 msgid "Games"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr ""
 
@@ -160,8 +161,8 @@ msgstr ""
 msgid "Remove Game"
 msgstr ""
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr ""
 
@@ -177,7 +178,7 @@ msgstr ""
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr ""
 
@@ -193,137 +194,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr ""
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr ""
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr ""
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr ""
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr ""
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr ""
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr ""
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr ""
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr ""
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr ""
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr ""
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr ""
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr ""
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr ""
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr ""
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr ""
 
@@ -351,135 +356,135 @@ msgstr ""
 msgid "Games you hide will appear here"
 msgstr ""
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr ""
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr ""
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr ""
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr ""
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr ""
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr ""
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr ""
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr ""
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr ""
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr ""
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr ""
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr ""
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr ""
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr ""
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr ""
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr ""
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr ""
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+msgid "translator-credits"
 msgstr ""
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr ""
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr ""
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr ""
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr ""
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr ""
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr ""
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr ""
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr ""
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -492,19 +497,19 @@ msgid ""
 "If the path contains spaces, make sure to wrap it in double quotes!"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr ""
 
@@ -518,49 +523,48 @@ msgid "{} unhidden"
 msgstr ""
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr ""
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr ""
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr ""
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr ""
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr ""
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr ""
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr ""
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr ""
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr ""
 
@@ -568,27 +572,27 @@ msgstr ""
 msgid "Importing Games…"
 msgstr ""
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr ""
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
 msgid "1 game imported"
-msgstr ""
+msgid_plural "{} games imported"
+msgstr[0] ""
+msgstr[1] ""
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr ""
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
 msgid "1 removed"
-msgstr ""
+msgid_plural "{} removed"
+msgstr[0] ""
+msgstr[1] ""
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34

--- a/po/cartridges.pot
+++ b/po/cartridges.pot
@@ -8,8 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
-"POT-Creation-Date: 2024-10-31 14:25+0100\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,7 +124,7 @@ msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:137 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr ""
 
@@ -199,32 +198,6 @@ msgstr ""
 msgid "Remove All Games"
 msgstr ""
 
-<<<<<<< HEAD
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
-msgstr ""
-
-#: data/gtk/preferences.blp:65
-msgid "Remove Uninstalled Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:70
-msgid "Sources"
-msgstr ""
-
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
-msgid "Steam"
-msgstr ""
-
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
-msgid "Install Location"
-msgstr ""
-
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
-=======
 #: data/gtk/preferences.blp:65
 msgid "Import Games Automatically"
 msgstr ""
@@ -253,52 +226,6 @@ msgstr ""
 msgid "Lutris"
 msgstr ""
 
-#: data/gtk/preferences.blp:127
-msgid "Import Steam Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:131
-msgid "Import Flatpak Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
-msgid "Heroic"
-msgstr ""
-
-#: data/gtk/preferences.blp:162
-msgid "Import Epic Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:166
-msgid "Import GOG Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:170
-msgid "Import Amazon Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:174
-msgid "Import Sideloaded Games"
-msgstr ""
-
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
-msgid "Bottles"
-msgstr ""
-
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
-msgid "itch"
-msgstr ""
-
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
-msgid "Legendary"
-msgstr ""
-
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
-msgid "RetroArch"
-msgstr ""
-
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
-=======
 #: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr ""
@@ -353,57 +280,6 @@ msgid "System Location"
 msgstr ""
 
 #. The location of the user-specific data directory
-<<<<<<< HEAD
-#: data/gtk/preferences.blp:315
-msgid "User Location"
-msgstr ""
-
-#: data/gtk/preferences.blp:332
-msgid "Import Game Launchers"
-msgstr ""
-
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
-msgid "Desktop Entries"
-msgstr ""
-
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
-msgid "SteamGridDB"
-msgstr ""
-
-#: data/gtk/preferences.blp:353
-msgid "Authentication"
-msgstr ""
-
-#: data/gtk/preferences.blp:356
-msgid "API Key"
-msgstr ""
-
-#: data/gtk/preferences.blp:364
-msgid "Use SteamGridDB"
-msgstr ""
-
-#: data/gtk/preferences.blp:365
-msgid "Download images when adding or importing games"
-msgstr ""
-
-#: data/gtk/preferences.blp:369
-msgid "Prefer Over Official Images"
-msgstr ""
-
-#: data/gtk/preferences.blp:373
-msgid "Prefer Animated Images"
-msgstr ""
-
-#: data/gtk/preferences.blp:379
-msgid "Update Covers"
-msgstr ""
-
-#: data/gtk/preferences.blp:380
-msgid "Fetch covers for games already in your library"
-msgstr ""
-
-#: data/gtk/preferences.blp:385
-=======
 #: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr ""
@@ -553,7 +429,6 @@ msgstr ""
 msgid "{} launched"
 msgstr ""
 
-<<<<<<< HEAD
 #. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 msgid "translator-credits"
@@ -652,13 +527,6 @@ msgstr ""
 msgid "{} removed"
 msgstr ""
 
-<<<<<<< HEAD
-#: cartridges/preferences.py:135
-msgid "All games removed"
-msgstr ""
-
-#: cartridges/preferences.py:187
-=======
 #: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr ""
@@ -668,33 +536,6 @@ msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 
-<<<<<<< HEAD
-#: cartridges/preferences.py:202
-msgid "Downloading covers…"
-msgstr ""
-
-#: cartridges/preferences.py:221
-msgid "Covers updated"
-msgstr ""
-
-#: cartridges/preferences.py:368
-msgid "Installation Not Found"
-msgstr ""
-
-#: cartridges/preferences.py:369
-msgid "Select a valid directory"
-msgstr ""
-
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
-msgid "Warning"
-msgstr ""
-
-#: cartridges/preferences.py:439
-msgid "Invalid Directory"
-msgstr ""
-
-#: cartridges/preferences.py:445
-=======
 #: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr ""
@@ -723,7 +564,7 @@ msgstr ""
 msgid "Set Location"
 msgstr ""
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr ""
 
@@ -731,23 +572,23 @@ msgstr ""
 msgid "Importing Games…"
 msgstr ""
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr ""
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] ""
 msgstr[1] ""
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 msgid "1 removed"
 msgid_plural "{} removed"
 msgstr[0] ""

--- a/po/cartridges.pot
+++ b/po/cartridges.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -523,9 +523,12 @@ msgid "{} unhidden"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
 msgid "{} removed"
-msgstr ""
+msgid_plural "{} removed"
+msgstr[0] ""
+msgstr[1] ""
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -568,6 +571,30 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+msgid "Last Week"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+msgid "Last Year"
+msgstr ""
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr ""
@@ -582,15 +609,8 @@ msgstr ""
 
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-msgid "1 removed"
-msgid_plural "{} removed"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/cartridges.pot
+++ b/po/cartridges.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -429,7 +429,7 @@ msgstr ""
 msgid "{} launched"
 msgstr ""
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 msgid "translator-credits"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-06-28 07:09+0000\n"
 "Last-Translator: foo expert <deferred_water346@simplelogin.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartridges/"
@@ -51,8 +51,8 @@ msgstr ""
 "her ze služeb Steam, Lutris, Heroic a dalších bez nutnosti přihlášení. Hry "
 "můžete třídit a skrývat nebo stahovat obálky ze služby SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Podrobnosti o hře"
 
@@ -61,8 +61,8 @@ msgid "Edit Game Details"
 msgstr "Upravit podrobnosti o hře"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Předvolby"
 
@@ -70,47 +70,47 @@ msgstr "Předvolby"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nový obal"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Odstranit obal"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Název"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Vývojář (nepovinné)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Spustitelný soubor"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Vybrat soubor"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Více informací"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Upravit"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Skrýt"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Odstranit"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Odkrýt"
 
@@ -118,17 +118,17 @@ msgstr "Odkrýt"
 msgid "General"
 msgstr "Obecné"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Vyhledávání"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Zpět"
 
@@ -136,11 +136,11 @@ msgstr "Zpět"
 msgid "Quit"
 msgstr "Ukončit"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Přepnout postranní panel"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Hlavní nabídka"
 
@@ -148,12 +148,12 @@ msgstr "Hlavní nabídka"
 msgid "Games"
 msgstr "Hry"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Přidat hru"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Import"
 
@@ -165,8 +165,8 @@ msgstr "Zobrazit skryté hry"
 msgid "Remove Game"
 msgstr "Odstranit hru"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Chování"
 
@@ -182,7 +182,7 @@ msgstr "Obrázek na obálce spouští hru"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Vymění chování obrázku na obálce a tlačítka pro přehrávání"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Obrázky"
 
@@ -198,137 +198,141 @@ msgstr "Ukládat obaly her bezztrátově na úkor většího místa na disku"
 msgid "Danger Zone"
 msgstr "Nebezpečná zóna"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Odstranit všechny hry"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Odstranit odinstalované hry"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Zdroje"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Umístění instalace"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importovat Steam hry"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importovat Flatpak hry"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importovat Epic Games hry"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importovat GOG hry"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importovat Amazon hry"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importovat ručně načtené hry"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Láhve"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Systémové umístění"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Uživatelské umístění"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importovat spouštěče her"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Položky na ploše"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Ověření"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Klíč API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Používat SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Stahovat obrázky při přidávání nebo importování her"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Upřednostnit před oficiálními obrázky"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Upřednostnit animované obrázky"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Aktualizovat obálky"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Najít obálky pro hry ve vaší knihovně"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Aktualizovat"
 
@@ -356,135 +360,136 @@ msgstr "Žádné skryté hry"
 msgid "Games you hide will appear here"
 msgstr "Hry, které skryjete, se zobrazí zde"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Všechny hry"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Přidané"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importované"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Skryté hry"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Název hry"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Hrát"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Třídit"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Ž"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Ž-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Nejnovější"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Nejstarší"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Naposledy hráno"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Zobrazit Skryté"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "O Kazetách"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} spuštěno"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "ooo.i.love.foo"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Přidáno: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nikdy"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Naposledy hráno: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Použít"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Přidat novou hru"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Přidat"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Spustitelné soubory"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "soubor.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\cesta\\k\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/cesta/k/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -506,19 +511,19 @@ msgstr ""
 "\n"
 "Pokud cesta obsahuje mezery, nezapomeňte ji zabalit do dvojitých uvozovek!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Nelze přidat hru"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Název hry nemůže být prázdný."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Spustitelný soubor nemůže být prázdný."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Nelze použít předvolby"
 
@@ -532,51 +537,50 @@ msgid "{} unhidden"
 msgstr "{} odkryto"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} odstraněno"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Všechny hry odstraněny"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "K používání služby SteamGridDB je vyžadován klíč API. Můžete si ho "
 "vygenerovat {}zde{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Stahování obálek…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Obálky aktualizovány"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Instalace nebyla nalezena"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Vyberte platný adresář"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Pozor"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Neplatný adresář"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Nastavit umístění"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Zahodit"
 
@@ -584,27 +588,31 @@ msgstr "Zahodit"
 msgid "Importing Games…"
 msgstr "Přidávání her…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Tyto chyby se vyskytly při importu:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nebyly nalezeny žádné nové hry"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "Přidána 1 hra"
+msgid_plural "{} games imported"
+msgstr[0] "Přidána 1 hra"
+msgstr[1] "Přidány {} hry"
+msgstr[2] "Přidány {} hry"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "Přidány {} hry"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 odstraněna"
+msgid_plural "{} removed"
+msgstr[0] "1 odstraněna"
+msgstr[1] "{} odstraněny"
+msgstr[2] "{} odstraněny"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -641,6 +649,9 @@ msgstr "Nelze ověřit SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Ověřte váš klíč API v předvolbách"
+
+#~ msgid "{} games imported"
+#~ msgstr "Přidány {} hry"
 
 #~ msgid "Cache Location"
 #~ msgstr "Umístění dočasných souborů"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-06-28 07:09+0000\n"
 "Last-Translator: foo expert <deferred_water346@simplelogin.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartridges/"
@@ -433,7 +433,7 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} spuštěno"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 #, fuzzy
 msgid "translator-credits"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-06-28 07:09+0000\n"
 "Last-Translator: foo expert <deferred_water346@simplelogin.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartridges/"
@@ -537,9 +537,14 @@ msgid "{} unhidden"
 msgstr "{} odkryto"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} odstraněno"
+msgid_plural "{} removed"
+msgstr[0] "{} odstraněno"
+msgstr[1] "{} odstraněno"
+msgstr[2] "{} odstraněno"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -584,6 +589,32 @@ msgstr "Nastavit umístění"
 msgid "Dismiss"
 msgstr "Zahodit"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Naposledy hráno"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Naposledy hráno"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Přidávání her…"
@@ -599,20 +630,11 @@ msgstr "Nebyly nalezeny žádné nové hry"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "Přidána 1 hra"
+msgstr[0] "Přidány {} hry"
 msgstr[1] "Přidány {} hry"
 msgstr[2] "Přidány {} hry"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 odstraněna"
-msgstr[1] "{} odstraněny"
-msgstr[2] "{} odstraněny"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,8 +672,19 @@ msgstr "Nelze ověřit SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Ověřte váš klíč API v předvolbách"
 
-#~ msgid "{} games imported"
-#~ msgstr "Přidány {} hry"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "Přidána 1 hra"
+#~ msgstr[1] "Přidány {} hry"
+#~ msgstr[2] "Přidány {} hry"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 odstraněna"
+#~ msgstr[1] "{} odstraněny"
+#~ msgstr[2] "{} odstraněny"
 
 #~ msgid "Cache Location"
 #~ msgstr "Umístění dočasných souborů"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-06-28 07:09+0000\n"
 "Last-Translator: foo expert <deferred_water346@simplelogin.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartridges/"
@@ -62,7 +62,7 @@ msgstr "Upravit podrobnosti o hře"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Předvolby"
 
@@ -128,7 +128,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Zpět"
 
@@ -166,7 +166,7 @@ msgid "Remove Game"
 msgstr "Odstranit hru"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Chování"
 
@@ -202,137 +202,137 @@ msgstr "Nebezpečná zóna"
 msgid "Remove All Games"
 msgstr "Odstranit všechny hry"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Odstranit odinstalované hry"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Zdroje"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Umístění instalace"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importovat Steam hry"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importovat Flatpak hry"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importovat Epic Games hry"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importovat GOG hry"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importovat Amazon hry"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importovat ručně načtené hry"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Láhve"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Systémové umístění"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Uživatelské umístění"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importovat spouštěče her"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Položky na ploše"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Ověření"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Klíč API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Používat SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Stahovat obrázky při přidávání nebo importování her"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Upřednostnit před oficiálními obrázky"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Upřednostnit animované obrázky"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Aktualizovat obálky"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Najít obálky pro hry ve vaší knihovně"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Aktualizovat"
 
@@ -541,46 +541,46 @@ msgstr "{} odkryto"
 msgid "{} removed"
 msgstr "{} odstraněno"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Všechny hry odstraněny"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "K používání služby SteamGridDB je vyžadován klíč API. Můžete si ho "
 "vygenerovat {}zde{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Stahování obálek…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Obálky aktualizovány"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalace nebyla nalezena"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Vyberte platný adresář"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Pozor"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Neplatný adresář"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Nastavit umístění"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Zahodit"
 
@@ -588,16 +588,16 @@ msgstr "Zahodit"
 msgid "Importing Games…"
 msgstr "Přidávání her…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Tyto chyby se vyskytly při importu:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nebyly nalezeny žádné nové hry"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -606,7 +606,7 @@ msgstr[1] "Přidány {} hry"
 msgstr[2] "Přidány {} hry"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Konstantin Tutsch <mail@konstantintutsch.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/cartridges/"
@@ -549,9 +549,13 @@ msgid "{} unhidden"
 msgstr "{} unversteckt"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} entfernt"
+msgid_plural "{} removed"
+msgstr[0] "{} entfernt"
+msgstr[1] "{} entfernt"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -596,6 +600,32 @@ msgstr "Ort festlegen"
 msgid "Dismiss"
 msgstr "Verstanden"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Heute"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Gestern"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Zuletzt gespielt"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Zuletzt gespielt"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Spiele werden importiert…"
@@ -611,18 +641,10 @@ msgstr "Keine neuen Spiele gefunden"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 Spiel importiert"
+msgstr[0] "{} Spiele importiert"
 msgstr[1] "{} Spiele importiert"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 entfernt"
-msgstr[1] "{} entfernt"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -660,8 +682,17 @@ msgstr "SteamGridDB konnte nicht authentifiziert werden"
 msgid "Verify your API key in preferences"
 msgstr "Verifiziere deinen API-Schlüssel in den Einstellungen"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} Spiele importiert"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 Spiel importiert"
+#~ msgstr[1] "{} Spiele importiert"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 entfernt"
+#~ msgstr[1] "{} entfernt"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache-Speicherort"
@@ -730,12 +761,6 @@ msgstr "Verifiziere deinen API-Schlüssel in den Einstellungen"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Bottles-Installationsort"
-
-#~ msgid "Today"
-#~ msgstr "Heute"
-
-#~ msgid "Yesterday"
-#~ msgstr "Gestern"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Wähle das Lutris-Cache-Verzeichnis aus."

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Konstantin Tutsch <mail@konstantintutsch.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/cartridges/"
@@ -56,8 +56,8 @@ msgstr ""
 "ohne dass eine Anmeldung erforderlich ist. Sie können Spiele sortieren und "
 "ausblenden oder Cover-Art von SteamGridDB herunterladen."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Spieldetails"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Spieldetails bearbeiten"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -75,47 +75,47 @@ msgstr "Einstellungen"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Neues Cover"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Cover löschen"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titel"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Entwickler (optional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Ausführbare Datei"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Datei auswählen"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Weitere Informationen"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Verstecken"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Entfernen"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Unverstecken"
 
@@ -123,17 +123,17 @@ msgstr "Unverstecken"
 msgid "General"
 msgstr "Allgemein"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Suchen"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -141,11 +141,11 @@ msgstr "Rückgängig"
 msgid "Quit"
 msgstr "Beenden"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Seitenleiste umschalten"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
@@ -153,12 +153,12 @@ msgstr "Hauptmenü"
 msgid "Games"
 msgstr "Spiele"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Spiel hinzufügen"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importieren"
 
@@ -170,8 +170,8 @@ msgstr "Ausgeblendete Spiele anzeigen"
 msgid "Remove Game"
 msgstr "Spiel entfernen"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Verhalten"
 
@@ -187,7 +187,7 @@ msgstr "Coverbild Startet Spiel"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Tauscht das Verhalten des Covers und des Spielen-Knopfes"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Bilder"
 
@@ -203,137 +203,141 @@ msgstr "Speichere Spielcovers verlustfrei auf Kosten des Speicherplatzes"
 msgid "Danger Zone"
 msgstr "Gefahrenzone"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Alle Spiele entfernen"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Deinstallierte Spiele entfernen"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Quellen"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Installationsort"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam-Spiele importieren"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak-Spiele importieren"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic Games importieren"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG-Spiele importieren"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon-Spiele importieren"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Sideloaded-Spiele importieren"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "System Ort"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Nutzer Ort"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Spiele-Launcher importieren"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop Einträge"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-Schlüssel"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB benutzen"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Lade Bilder herunter, wenn Spiele hinzugefügt oder importiert werden"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Über offiziellen Bildern bevorzugen"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Animierte Bilder bevorzugen"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Cover aktualisieren"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Cover für in der Bibliothek vorhandene Spiele laden"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Aktualisieren"
 
@@ -361,135 +365,136 @@ msgstr "Keine versteckten Spiele"
 msgid "Games you hide will appear here"
 msgstr "Ausgeblendete Spiele, werden hier angezeigt"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Alle Spiele"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Hinzugefügt"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importiert"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Ausgeblendete Spiele"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Spieltitel"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Spielen"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sortierung"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Neuestes"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Älteste"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Zuletzt gespielt"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Ausgeblendete anzeigen"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Über Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} gestartet"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Feliks Weber"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Hinzugefügt: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nie"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Zuletzt gespielt: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Anwenden"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Neues Spiel hinzufügen"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Ausführbare Dateien"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "datei.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "Programm"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\pfad\\zu\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/pfad/zu/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "Falls der Pfad Leerzeichen enthält, stelle sicher ihn in doppelte "
 "Anführungszeichen zu setzen!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Konnte Spiel nicht hinzufügen"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Spieltitel kann nicht leer sein."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Ausführbare Datei darf nicht leer sein."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Einstellungen konnten nicht angewendet werden"
 
@@ -538,51 +543,50 @@ msgid "{} unhidden"
 msgstr "{} unversteckt"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} entfernt"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Alle Spiele entfernt"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Für die Nutzung von SteamGridDB ist ein API-Schlüssel erforderlich. Sie "
 "können ihn {}hier{} generieren."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Cover werden geladen…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Cover aktualisiert"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installation nicht gefunden"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Wähle ein gültiges Verzeichnis aus"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Warnung"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Ungültiges Verzeichnis"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Ort festlegen"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Verstanden"
 
@@ -590,27 +594,29 @@ msgstr "Verstanden"
 msgid "Importing Games…"
 msgstr "Spiele werden importiert…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Die folgenden Fehler sind beim Import aufgetreten:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Keine neuen Spiele gefunden"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 Spiel importiert"
+msgid_plural "{} games imported"
+msgstr[0] "1 Spiel importiert"
+msgstr[1] "{} Spiele importiert"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} Spiele importiert"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 entfernt"
+msgid_plural "{} removed"
+msgstr[0] "1 entfernt"
+msgstr[1] "{} entfernt"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -647,6 +653,9 @@ msgstr "SteamGridDB konnte nicht authentifiziert werden"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifiziere deinen API-Schlüssel in den Einstellungen"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} Spiele importiert"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache-Speicherort"

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Konstantin Tutsch <mail@konstantintutsch.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/cartridges/"
@@ -438,11 +438,17 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} gestartet"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 #, fuzzy
 msgid "translator-credits"
-msgstr "Feliks Weber"
+msgstr ""
+"Feliks Weber\n"
+"Jummit <jummit@web.de>\n"
+"WebSnke <websnke@tutanota.com>\n"
+"Ettore Atalan <atalanttore@googlemail.com>\n"
+"Simon Hahne <simonhahne@web.de>\n"
+"Konstantin Tutsch <mail@konstantintutsch.com>"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Konstantin Tutsch <mail@konstantintutsch.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/cartridges/"
@@ -67,7 +67,7 @@ msgstr "Spieldetails bearbeiten"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Spiel entfernen"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Verhalten"
 
@@ -207,137 +207,137 @@ msgstr "Gefahrenzone"
 msgid "Remove All Games"
 msgstr "Alle Spiele entfernen"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Deinstallierte Spiele entfernen"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Quellen"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Installationsort"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam-Spiele importieren"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak-Spiele importieren"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic Games importieren"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG-Spiele importieren"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon-Spiele importieren"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Sideloaded-Spiele importieren"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "System Ort"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Nutzer Ort"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Spiele-Launcher importieren"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop Einträge"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-Schlüssel"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB benutzen"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Lade Bilder herunter, wenn Spiele hinzugefügt oder importiert werden"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Über offiziellen Bildern bevorzugen"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Animierte Bilder bevorzugen"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Cover aktualisieren"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Cover für in der Bibliothek vorhandene Spiele laden"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Aktualisieren"
 
@@ -553,46 +553,46 @@ msgstr "{} unversteckt"
 msgid "{} removed"
 msgstr "{} entfernt"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Alle Spiele entfernt"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Für die Nutzung von SteamGridDB ist ein API-Schlüssel erforderlich. Sie "
 "können ihn {}hier{} generieren."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Cover werden geladen…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Cover aktualisiert"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installation nicht gefunden"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Wähle ein gültiges Verzeichnis aus"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Warnung"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Ungültiges Verzeichnis"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Ort festlegen"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Verstanden"
 
@@ -600,16 +600,16 @@ msgstr "Verstanden"
 msgid "Importing Games…"
 msgstr "Spiele werden importiert…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Die folgenden Fehler sind beim Import aufgetreten:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Keine neuen Spiele gefunden"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -617,7 +617,7 @@ msgstr[0] "1 Spiel importiert"
 msgstr[1] "{} Spiele importiert"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-10-08 16:00+0000\n"
 "Last-Translator: yiannis ioannides <sub@wai.ai>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/cartridges/"
@@ -544,9 +544,13 @@ msgid "{} unhidden"
 msgstr "{} φανερώθηκε"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} αφαιρέθηκε"
+msgid_plural "{} removed"
+msgstr[0] "{} αφαιρέθηκε"
+msgstr[1] "{} αφαιρέθηκε"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -591,6 +595,32 @@ msgstr "Ορίστε Τοποθεσία"
 msgid "Dismiss"
 msgstr "Απόρριψη"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Σήμερα"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Χθες"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Τελευταία αναπαραγωγή"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Τελευταία αναπαραγωγή"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Εισαγωγή παιχνιδιών…"
@@ -606,18 +636,10 @@ msgstr "Δεν βρέθηκαν νέα παιχνίδια"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 παιχνίδι εισήχθη"
+msgstr[0] "{} παιχνίδια εισήχθησαν"
 msgstr[1] "{} παιχνίδια εισήχθησαν"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 αφαιρέθηκε"
-msgstr[1] "{} αφαιρέθηκε"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -656,8 +678,17 @@ msgstr ""
 msgid "Verify your API key in preferences"
 msgstr "Επιβεβαιώστε το κλειδί API σας στις ρυθμίσεις"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} παιχνίδια εισήχθησαν"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 παιχνίδι εισήχθη"
+#~ msgstr[1] "{} παιχνίδια εισήχθησαν"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 αφαιρέθηκε"
+#~ msgstr[1] "{} αφαιρέθηκε"
 
 #~ msgid "Cache Location"
 #~ msgstr "Τοποθεσία cache"
@@ -723,12 +754,6 @@ msgstr "Επιβεβαιώστε το κλειδί API σας στις ρυθμ�
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Τοποθεσία Εγκατάστασης Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Σήμερα"
-
-#~ msgid "Yesterday"
-#~ msgstr "Χθες"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Επιλέξτε τη τοποθεσία cache του Lutris."

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-10-08 16:00+0000\n"
 "Last-Translator: yiannis ioannides <sub@wai.ai>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "να κρύψετε τα παιχνίδια σας, καθώς και να κατεβάσετε τα εξώφυλλα τους από το "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Λεπτομέρειες Παιχνιδιού"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "Επεξεργασία Λεπτομερειών Παιχνιδιού"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
@@ -73,47 +73,47 @@ msgstr "Προτιμήσεις"
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Νέο Εξώφυλλο"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Διαγραφή Εξώφυλλου"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Τίτλος"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Προγραμματιστής (προαιρετικό)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Εκτελέσιμο αρχείο"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Επιλογή αρχείου"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Περισσότερες Πληροφορίες"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Απόκρυψη"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Φανέρωση"
 
@@ -121,17 +121,17 @@ msgstr "Φανέρωση"
 msgid "General"
 msgstr "Γενικά"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Συντομεύσεις Πληκτρολογίου"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Αναίρεση"
 
@@ -139,11 +139,11 @@ msgstr "Αναίρεση"
 msgid "Quit"
 msgstr "Κλείσιμο"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Ρύθμιση πάνελ"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Κύριο μενού"
 
@@ -151,12 +151,12 @@ msgstr "Κύριο μενού"
 msgid "Games"
 msgstr "Παιχνίδια"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Προσθήκη παιχνιδιού"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Εισαγωγή"
 
@@ -168,8 +168,8 @@ msgstr "Εμφάνιση κρυμμένων παιχνιδιών"
 msgid "Remove Game"
 msgstr "Αφαίρεση παιχνιδιού"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Συμπεριφορά"
 
@@ -185,7 +185,7 @@ msgstr "Εξώφυλλο εκκινεί το παιχνίδι"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Αντικατάσταση συμπεριφοράς εξωφύλλου και του κουμπιού αναπαραγωγής"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Εικόνες"
 
@@ -202,139 +202,143 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Επικίνδυνη Ζώνη"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Αφαίρεση Όλων Των Παιχνιδιών"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Αφαίρεση απεγκατεστημένων παιχνιδιών"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Πηγές"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Τοποθεσία εγκατάστασης"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Εισαγωγή παιχνιδιών Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Εισαγωγή παιχνιδιών Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Εισαγωγή παιχνιδιών Epic"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Εισαγωγή παιχνιδιών GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Εισαγωγή παιχνιδιών Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Εισαγωγή παιχνιδιών μέσω sideloading"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 #, fuzzy
 msgid "System Location"
 msgstr "Ορίστε Τοποθεσία"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 #, fuzzy
 msgid "User Location"
 msgstr "Ορίστε Τοποθεσία"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Εισαγωγή εκκινητών παιχνιδιών"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Εισαγωγές desktop"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Επιβεβαίωση"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Κλειδί API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Χρήση SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Λήψη εικόνων κατά τη διάρκεια πρόσθεσης ή εισαγωγής παιχνιδιών"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Προτίμηση Επίσημων Εικόνων"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Προτίμηση Κινούμενων Εικόνων"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Ανανέωση εξώφυλλου"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Ανάκτηση εξώφυλλων για τα προϋπάρχων παιχνίδια στη βιβλιοθήκη σας"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Ανανέωση"
 
@@ -362,135 +366,136 @@ msgstr "Δεν υπάρχουν κρυφά παιχνίδια"
 msgid "Games you hide will appear here"
 msgstr "Τα παιχνίδια που κρύβετε θα εμφανίζονται εδώ"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Όλα τα παιχνίδια"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Προστέθηκε"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Εισήχθη"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Κρυμμένα παιχνίδια"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Τίτλος παιχνιδιού"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Παίξτε"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ταξινόμηση"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "Α-Ζ"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Ζ-Α"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Νεότερο"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Παλαιότερο"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Τελευταία αναπαραγωγή"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Εμφάνιση Κρυφών"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Σχετικά με τις Κασέτες"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr ""
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr ""
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} εκκινήθη"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Yiannis Ioannides"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Προστέθηκε: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Ποτέ"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Τελευταία αναπαραγωγή: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Εφαρμογή"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Προσθήκη νέου παιχνιδιού"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Προγράμματα"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "αρχειο.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "πρόγραμμα"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\προς\\φάκελο\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/προς/φάκελο/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -514,19 +519,19 @@ msgstr ""
 "Αν η διεύθυνση φακέλου περιέχει κενά, φροντίστε να την περικλείσετε σε διπλά "
 "εισαγωγικά!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Αδυναμία προσθήκης παιχνιδιού"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Ο τίτλος παιχνιδιού δεν μπορεί να είναι κενός."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Η εφαρμογή δεν μπορεί να είναι κενή."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Αδυναμία Εφαρμογής Προτιμήσεων"
 
@@ -540,51 +545,50 @@ msgid "{} unhidden"
 msgstr "{} φανερώθηκε"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} αφαιρέθηκε"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Όλα τα παιχνίδια αφαιρέθηκαν"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Για τη χρήση του SteamGridDB απαιτείται ένα κλειδί API. Μπορείτε να "
 "δημιουργήσετε ένα {}εδώ{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Λήψη εξώφυλλων…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Τα εξώφυλλα ανανεώθηκαν"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Η εγκατάσταση δεν βρέθηκε"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Επιλέξτε έναν έγκυρο προορισμό"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Προσοχή"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Μη έγκυρος προορισμός"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Ορίστε Τοποθεσία"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Απόρριψη"
 
@@ -592,27 +596,29 @@ msgstr "Απόρριψη"
 msgid "Importing Games…"
 msgstr "Εισαγωγή παιχνιδιών…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Τα παρακάτω σφάλματα παρουσιάστηκαν κατά την εισαγωγή:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Δεν βρέθηκαν νέα παιχνίδια"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 παιχνίδι εισήχθη"
+msgid_plural "{} games imported"
+msgstr[0] "1 παιχνίδι εισήχθη"
+msgstr[1] "{} παιχνίδια εισήχθησαν"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} παιχνίδια εισήχθησαν"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 αφαιρέθηκε"
+msgid_plural "{} removed"
+msgstr[0] "1 αφαιρέθηκε"
+msgstr[1] "{} αφαιρέθηκε"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,6 +656,9 @@ msgstr ""
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Επιβεβαιώστε το κλειδί API σας στις ρυθμίσεις"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} παιχνίδια εισήχθησαν"
 
 #~ msgid "Cache Location"
 #~ msgstr "Τοποθεσία cache"

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-10-08 16:00+0000\n"
 "Last-Translator: yiannis ioannides <sub@wai.ai>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/cartridges/"
@@ -439,9 +439,8 @@ msgstr ""
 msgid "{} launched"
 msgstr "{} εκκινήθη"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Yiannis Ioannides"
 

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-10-08 16:00+0000\n"
 "Last-Translator: yiannis ioannides <sub@wai.ai>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "Επεξεργασία Λεπτομερειών Παιχνιδιού"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Συντομεύσεις Πληκτρολογίου"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Αναίρεση"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "Αφαίρεση παιχνιδιού"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Συμπεριφορά"
 
@@ -206,139 +206,139 @@ msgstr "Επικίνδυνη Ζώνη"
 msgid "Remove All Games"
 msgstr "Αφαίρεση Όλων Των Παιχνιδιών"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Αφαίρεση απεγκατεστημένων παιχνιδιών"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Πηγές"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Τοποθεσία εγκατάστασης"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Εισαγωγή παιχνιδιών Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Εισαγωγή παιχνιδιών Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Εισαγωγή παιχνιδιών Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Εισαγωγή παιχνιδιών GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Εισαγωγή παιχνιδιών Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Εισαγωγή παιχνιδιών μέσω sideloading"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 #, fuzzy
 msgid "System Location"
 msgstr "Ορίστε Τοποθεσία"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 #, fuzzy
 msgid "User Location"
 msgstr "Ορίστε Τοποθεσία"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Εισαγωγή εκκινητών παιχνιδιών"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Εισαγωγές desktop"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Επιβεβαίωση"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Κλειδί API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Χρήση SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Λήψη εικόνων κατά τη διάρκεια πρόσθεσης ή εισαγωγής παιχνιδιών"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Προτίμηση Επίσημων Εικόνων"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Προτίμηση Κινούμενων Εικόνων"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Ανανέωση εξώφυλλου"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Ανάκτηση εξώφυλλων για τα προϋπάρχων παιχνίδια στη βιβλιοθήκη σας"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Ανανέωση"
 
@@ -548,46 +548,46 @@ msgstr "{} φανερώθηκε"
 msgid "{} removed"
 msgstr "{} αφαιρέθηκε"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Όλα τα παιχνίδια αφαιρέθηκαν"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Για τη χρήση του SteamGridDB απαιτείται ένα κλειδί API. Μπορείτε να "
 "δημιουργήσετε ένα {}εδώ{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Λήψη εξώφυλλων…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Τα εξώφυλλα ανανεώθηκαν"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Η εγκατάσταση δεν βρέθηκε"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Επιλέξτε έναν έγκυρο προορισμό"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Προσοχή"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Μη έγκυρος προορισμός"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Ορίστε Τοποθεσία"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Απόρριψη"
 
@@ -595,16 +595,16 @@ msgstr "Απόρριψη"
 msgid "Importing Games…"
 msgstr "Εισαγωγή παιχνιδιών…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Τα παρακάτω σφάλματα παρουσιάστηκαν κατά την εισαγωγή:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Δεν βρέθηκαν νέα παιχνίδια"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -612,7 +612,7 @@ msgstr[0] "1 παιχνίδι εισήχθη"
 msgstr[1] "{} παιχνίδια εισήχθησαν"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-03-24 15:19+0000\n"
 "Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -539,9 +539,13 @@ msgid "{} unhidden"
 msgstr "{} unhidden"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} removed"
+msgid_plural "{} removed"
+msgstr[0] "{} removed"
+msgstr[1] "{} removed"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -585,6 +589,32 @@ msgstr "Set Location"
 msgid "Dismiss"
 msgstr "Dismiss"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Last Played"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Last Played"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importing Games…"
@@ -600,18 +630,10 @@ msgstr "No new games found"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 game imported"
-msgstr[1] "1 game imported"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 removed"
-msgstr[1] "1 removed"
+msgstr[0] "{} games imported"
+msgstr[1] "{} games imported"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -649,8 +671,17 @@ msgstr "Couldn't Authenticate SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verify your API key in preferences"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} games imported"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 game imported"
+#~ msgstr[1] "1 game imported"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 removed"
+#~ msgstr[1] "1 removed"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache Location"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-03-24 15:19+0000\n"
 "Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -435,7 +435,7 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} launched"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 #, fuzzy
 msgid "translator-credits"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-03-24 15:19+0000\n"
 "Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -53,8 +53,8 @@ msgstr ""
 "necessary. You can sort and hide games or download cover art from "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Game Details"
 
@@ -63,8 +63,8 @@ msgid "Edit Game Details"
 msgstr "Edit Game Details"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferences"
 
@@ -72,47 +72,47 @@ msgstr "Preferences"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "New Cover"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Delete Cover"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Title"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Developer (optional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Executable"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Select File"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "More Info"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Edit"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Hide"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Remove"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Unhide"
 
@@ -120,17 +120,17 @@ msgstr "Unhide"
 msgid "General"
 msgstr "General"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Search"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Undo"
 
@@ -138,11 +138,11 @@ msgstr "Undo"
 msgid "Quit"
 msgstr "Quit"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Toggle Sidebar"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Main Menu"
 
@@ -150,12 +150,12 @@ msgstr "Main Menu"
 msgid "Games"
 msgstr "Games"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Add Game"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Import"
 
@@ -167,8 +167,8 @@ msgstr "Show Hidden Games"
 msgid "Remove Game"
 msgstr "Remove Game"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Behaviour"
 
@@ -184,7 +184,7 @@ msgstr "Cover Image Launches Game"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Swaps the behaviour of the cover image and the play button"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Images"
 
@@ -200,137 +200,141 @@ msgstr "Save game covers losslessly at the cost of storage"
 msgid "Danger Zone"
 msgstr "Danger Zone"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Remove All Games"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Remove Uninstalled Games"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Sources"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Install Location"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Import Steam Games"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Import Flatpak Games"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Import Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Import GOG Games"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Import Amazon Games"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Import Sideloaded Games"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "System Location"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "User Location"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Import Game Launchers"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop Entries"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Authentication"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API Key"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Use SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Download images when adding or importing games"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Prefer Over Official Images"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Prefer Animated Images"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Update Covers"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Fetch covers for games already in your library"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Update"
 
@@ -358,135 +362,136 @@ msgstr "No Hidden Games"
 msgid "Games you hide will appear here"
 msgstr "Games you hide will appear here"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "All Games"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Added"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Imported"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Hidden Games"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Game Title"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Play"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sort"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Newest"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Oldest"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Last Played"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Show Hidden"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "About Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} launched"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Bruce Cowan <bruce@bcowan.me.uk>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Added: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Never"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Last played: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Apply"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Add New Game"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Add"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Executables"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\path\\to\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/path/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -508,19 +513,19 @@ msgstr ""
 "\n"
 "If the path contains spaces, make sure to wrap it in double quotes!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Couldn't Add Game"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Game title cannot be empty."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Executable cannot be empty."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Couldn't Apply Preferences"
 
@@ -534,50 +539,49 @@ msgid "{} unhidden"
 msgstr "{} unhidden"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} removed"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "All games removed"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Downloading covers…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Covers updated"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installation Not Found"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Select a valid directory"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Warning"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Invalid Directory"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Set Location"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Dismiss"
 
@@ -585,27 +589,29 @@ msgstr "Dismiss"
 msgid "Importing Games…"
 msgstr "Importing Games…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "The following errors occured during import:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "No new games found"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 game imported"
+msgid_plural "{} games imported"
+msgstr[0] "1 game imported"
+msgstr[1] "1 game imported"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} games imported"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 removed"
+msgid_plural "{} removed"
+msgstr[0] "1 removed"
+msgstr[1] "1 removed"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -642,6 +648,9 @@ msgstr "Couldn't Authenticate SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verify your API key in preferences"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} games imported"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache Location"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-03-24 15:19+0000\n"
 "Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -64,7 +64,7 @@ msgstr "Edit Game Details"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferences"
 
@@ -130,7 +130,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Undo"
 
@@ -168,7 +168,7 @@ msgid "Remove Game"
 msgstr "Remove Game"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Behaviour"
 
@@ -204,137 +204,137 @@ msgstr "Danger Zone"
 msgid "Remove All Games"
 msgstr "Remove All Games"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Remove Uninstalled Games"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Sources"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Install Location"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Import Steam Games"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Import Flatpak Games"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Import Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Import GOG Games"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Import Amazon Games"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Import Sideloaded Games"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "System Location"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "User Location"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Import Game Launchers"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop Entries"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Authentication"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API Key"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Use SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Download images when adding or importing games"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Prefer Over Official Images"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Prefer Animated Images"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Update Covers"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Fetch covers for games already in your library"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Update"
 
@@ -543,45 +543,45 @@ msgstr "{} unhidden"
 msgid "{} removed"
 msgstr "{} removed"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "All games removed"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Downloading covers…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Covers updated"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installation Not Found"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Select a valid directory"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Warning"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Invalid Directory"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Set Location"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Dismiss"
 
@@ -589,16 +589,16 @@ msgstr "Dismiss"
 msgid "Importing Games…"
 msgstr "Importing Games…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "The following errors occured during import:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "No new games found"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -606,7 +606,7 @@ msgstr[0] "1 game imported"
 msgstr[1] "1 game imported"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -439,9 +439,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} comenzó"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -67,7 +67,7 @@ msgstr "Editar detalles del juego"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Deshacer"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Eliminar juego"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportamiento"
 
@@ -208,137 +208,137 @@ msgstr "Zona de peligro"
 msgid "Remove All Games"
 msgstr "Eliminar todos los juegos"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Eliminar los juegos desinstalados"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Fuentes"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Ruta de instalación"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importar juegos de Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importar juegos Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importar juegos de Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importar juegos de GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importar juegos de Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importar juegos descargados"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendario"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Ubicación del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Ubicación del usuario"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importar lanzadores de juegos"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas de escritorio"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Clave API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Descargar las imágenes al añadir o importar juegos"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferir las imágenes oficiales"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Prefiero las imágenes animadas"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Actualizar las portadas"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Busca las portadas de los juegos de su biblioteca"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Actualizar"
 
@@ -546,46 +546,46 @@ msgstr "{} visible"
 msgid "{} removed"
 msgstr "{} eliminado"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Todos los juegos eliminados"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Se necesita una clave API para utilizar SteamGridDB. Puedes generar una {}"
 "aquí{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Descargando las portadas…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Portadas actualizadas"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalación no encontrada"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Seleccione un directorio válido"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Advertencia"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Directorio no válido"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Escoger la ubicación"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -593,16 +593,16 @@ msgstr "Descartar"
 msgid "Importing Games…"
 msgstr "Importando juegos…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Han sucedido los siguientes fallos durante la importación:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "No se encontraron juegos nuevos"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[0] "1 juego importado"
 msgstr[1] "{} juegos importados"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -56,8 +56,8 @@ msgstr ""
 "iniciar sesión. Puede ordenar y ocultar juegos o descargar portadas de "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalles del juego"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Editar detalles del juego"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -75,47 +75,47 @@ msgstr "Preferencias"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Portada nueva"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Borrar portada"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Título"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Desarrollador (opcional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Ejecutable"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Seleccionar archivo"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Más información"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Editar"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Ocultar"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Eliminar"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Desocultar"
 
@@ -123,17 +123,17 @@ msgstr "Desocultar"
 msgid "General"
 msgstr "General"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Buscar"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Deshacer"
 
@@ -141,11 +141,11 @@ msgstr "Deshacer"
 msgid "Quit"
 msgstr "Salir"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Conmutar la barra lateral"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menú principal"
 
@@ -153,12 +153,12 @@ msgstr "Menú principal"
 msgid "Games"
 msgstr "Juegos"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Añadir juego"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importar"
 
@@ -170,8 +170,8 @@ msgstr "Mostrar juegos ocultos"
 msgid "Remove Game"
 msgstr "Eliminar juego"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportamiento"
 
@@ -188,7 +188,7 @@ msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 "Cambia el comportamiento de la imagen de portada y del botón de reproducción"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Imágenes"
 
@@ -204,137 +204,141 @@ msgstr "Guarda las partidas sin pérdidas a costa del almacenamiento"
 msgid "Danger Zone"
 msgstr "Zona de peligro"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Eliminar todos los juegos"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Eliminar los juegos desinstalados"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Fuentes"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Ruta de instalación"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importar juegos de Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importar juegos Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importar juegos de Epic"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importar juegos de GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importar juegos de Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importar juegos descargados"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendario"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Ubicación del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Ubicación del usuario"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importar lanzadores de juegos"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas de escritorio"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Clave API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Descargar las imágenes al añadir o importar juegos"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferir las imágenes oficiales"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Prefiero las imágenes animadas"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Actualizar las portadas"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Busca las portadas de los juegos de su biblioteca"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Actualizar"
 
@@ -362,135 +366,136 @@ msgstr "No hay juegos ocultos"
 msgid "Games you hide will appear here"
 msgstr "Los juegos que oculte aparecerán aquí"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Todos los juegos"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Añadido"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importado"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Juegos ocultos"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Título del juego"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Jugar"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordenar"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Más recientes"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Más antiguos"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Último jugado"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Mostrar ocultos"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Acerca de Cartuchos"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} comenzó"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Añadido: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nunca"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Último jugado: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Aplicar"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Añadir un nuevo Juego"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Añadir"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Ejecutables"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "archivo.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programa"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\ruta\\hasta\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/ruta/hasta/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "\n"
 "Si la ruta contiene espacios, ¡asegúrese de entrecomillarla!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "No se puede añadir el juego"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "El título del juego no puede estar vacío."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "El ejecutable no puede estar vacío."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "No se pudieron aplicar las preferencias"
 
@@ -538,51 +543,50 @@ msgid "{} unhidden"
 msgstr "{} visible"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} eliminado"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Todos los juegos eliminados"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Se necesita una clave API para utilizar SteamGridDB. Puedes generar una {}"
 "aquí{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Descargando las portadas…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Portadas actualizadas"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Instalación no encontrada"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Seleccione un directorio válido"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Advertencia"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Directorio no válido"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Escoger la ubicación"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -590,27 +594,29 @@ msgstr "Descartar"
 msgid "Importing Games…"
 msgstr "Importando juegos…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Han sucedido los siguientes fallos durante la importación:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "No se encontraron juegos nuevos"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 juego importado"
+msgid_plural "{} games imported"
+msgstr[0] "1 juego importado"
+msgstr[1] "{} juegos importados"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} juegos importados"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 eliminado"
+msgid_plural "{} removed"
+msgstr[0] "1 eliminado"
+msgstr[1] "{} eliminados"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -648,6 +654,9 @@ msgstr "No se ha podido autenticar SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifique su clave API en las preferencias"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} juegos importados"
 
 #~ msgid "Cache Location"
 #~ msgstr "Ruta de la caché"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-02-19 06:35+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -542,9 +542,13 @@ msgid "{} unhidden"
 msgstr "{} visible"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} eliminado"
+msgid_plural "{} removed"
+msgstr[0] "{} eliminado"
+msgstr[1] "{} eliminado"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -589,6 +593,32 @@ msgstr "Escoger la ubicación"
 msgid "Dismiss"
 msgstr "Descartar"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Hoy"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Ayer"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Último jugado"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Último jugado"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importando juegos…"
@@ -604,18 +634,10 @@ msgstr "No se encontraron juegos nuevos"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 juego importado"
+msgstr[0] "{} juegos importados"
 msgstr[1] "{} juegos importados"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 eliminado"
-msgstr[1] "{} eliminados"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -654,8 +676,17 @@ msgstr "No se ha podido autenticar SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifique su clave API en las preferencias"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} juegos importados"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 juego importado"
+#~ msgstr[1] "{} juegos importados"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 eliminado"
+#~ msgstr[1] "{} eliminados"
 
 #~ msgid "Cache Location"
 #~ msgstr "Ruta de la caché"
@@ -718,12 +749,6 @@ msgstr "Verifique su clave API en las preferencias"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Ubicación de instalación de Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Hoy"
-
-#~ msgid "Yesterday"
-#~ msgstr "Ayer"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Caché no encontrada"

--- a/po/fa.po
+++ b/po/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-07-14 20:09+0000\n"
 "Last-Translator: آوید <avds+git@disroot.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/cartridges/"
@@ -539,9 +539,13 @@ msgid "{} unhidden"
 msgstr "{} نانهفته"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} برداشته"
+msgid_plural "{} removed"
+msgstr[0] "{} برداشته"
+msgstr[1] "{} برداشته"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -586,6 +590,32 @@ msgstr "تنظیم مکان"
 msgid "Dismiss"
 msgstr "رد"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "آخرین بازی‌شده"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "آخرین بازی‌شده"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "درون‌ریزی بازی‌ها…"
@@ -601,18 +631,10 @@ msgstr "هیچ بازی جدیدی پیدا نشد"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "یک بازی درون‌ریخته شد"
+msgstr[0] "{} بازی درون‌ریخته شدند"
 msgstr[1] "{} بازی درون‌ریخته شدند"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "یکی برداشته شد"
-msgstr[1] "{} برداشته شد"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,8 +672,17 @@ msgstr "نتوانست در SteamGridDB هویت‌سنجی کند"
 msgid "Verify your API key in preferences"
 msgstr "کلید APIتان را در ترجیحات تأیید کنید"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} بازی درون‌ریخته شدند"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "یک بازی درون‌ریخته شد"
+#~ msgstr[1] "{} بازی درون‌ریخته شدند"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "یکی برداشته شد"
+#~ msgstr[1] "{} برداشته شد"
 
 #~ msgid "Cache Location"
 #~ msgstr "مکان انباره"

--- a/po/fa.po
+++ b/po/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-07-14 20:09+0000\n"
 "Last-Translator: آوید <avds+git@disroot.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "ویرایش جزییات بازی"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "ترجیحات"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "میان‌برهای صفحه‌کلید"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "برگردان"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "برداشتن بازی"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "رفتار"
 
@@ -205,137 +205,137 @@ msgstr "منطقهٔ خطر"
 msgid "Remove All Games"
 msgstr "حذف کردن همهٔ بازی‌ها"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "برداشتن بازی‌های نصب‌نشده"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "منبع‌ها"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "استیم"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "مکان نصب"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "لوتریس"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "درون‌ریزی بازی‌های استیم"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "درون‌ریزی بازی‌های فلت‌پک"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "هروییک"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "درون‌ریزی بازی‌های اپیک"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "درون‌ریزی بازی‌های گوگ"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "درون‌ریزی بازی‌های آمازون"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "درون‌ریزی بازی‌های نصب‌شده"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "بطری‌ها"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "ایچ"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "لجندری"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "رتروآرچ"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "فلت‌پک"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "مکان سامانه"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "مکان کاربر"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "درون‌ریزی اجراگرهای بازی"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "ورودی‌های میزکار"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "هویت‌سنجی"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "کلید API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "استفاده از SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "بارگیری تصویرها هنگام افزودن یا درون‌ریزی بازی‌ها"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "ترجیح به تصویرهای رسمی"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "ترجیح تصویرهای پویا"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "به‌روزرسانی طرح جلد"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "دریافت طرح جلد بازی‌های کنونی کتاب‌خانه‌تان"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "به‌روزرسانی"
 
@@ -543,46 +543,46 @@ msgstr "{} نانهفته"
 msgid "{} removed"
 msgstr "{} برداشته"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "همهٔ بازی‌ها برداشته شدند"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "برای استفاده از SteamGridDB نیاز به یک کلید API است. می‌توانید {}این‌جا{} یکی "
 "بسازید."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "در حال دریافت طرح‌های جلد…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "طرح‌های جلد به‌روزرسانی شد"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "نصب پیدا نشد"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "گزینش شاخه‌ای معتبر"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "هشدار"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "شاخهٔ نامعتبر"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "تنظیم مکان"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "رد"
 
@@ -590,16 +590,16 @@ msgstr "رد"
 msgid "Importing Games…"
 msgstr "درون‌ریزی بازی‌ها…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "هنگام درون‌ریزی خطاهای زیر رخ دادند:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "هیچ بازی جدیدی پیدا نشد"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -607,7 +607,7 @@ msgstr[0] "یک بازی درون‌ریخته شد"
 msgstr[1] "{} بازی درون‌ریخته شدند"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/fa.po
+++ b/po/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-07-14 20:09+0000\n"
 "Last-Translator: آوید <avds+git@disroot.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/cartridges/"
@@ -436,9 +436,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} اجرا شد"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "دانیال بهزادی <dani.behzi@ubuntu.com>"
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-07-14 20:09+0000\n"
 "Last-Translator: آوید <avds+git@disroot.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "نیاز به ورود، بازی‌هایتان را از استیم، لوتریس، هروییک و… وارد کند. می‌توانید "
 "بازی‌هایتان را نهفته یا طرح جلدشان را از SteamGridDB بگیرید."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "جزییات بازی"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "ویرایش جزییات بازی"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "ترجیحات"
 
@@ -73,47 +73,47 @@ msgstr "ترجیحات"
 msgid "Cancel"
 msgstr "لغو"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "طرح جلد جدید"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "حذف طرح جلد"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "عنوان"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "توسعه‌دهنده (اختیاری)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "اجرایی"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "گزینش پرونده"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "اطلاعات بیشتر"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "ویرایش"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "نهفتن"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "برداشتن"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "نانهفتن"
 
@@ -121,17 +121,17 @@ msgstr "نانهفتن"
 msgid "General"
 msgstr "عمومی"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "جست‌وجو"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "میان‌برهای صفحه‌کلید"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "برگردان"
 
@@ -139,11 +139,11 @@ msgstr "برگردان"
 msgid "Quit"
 msgstr "خروج"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "تغییر وضعیت نوار کناری"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "فهرست اصلی"
 
@@ -151,12 +151,12 @@ msgstr "فهرست اصلی"
 msgid "Games"
 msgstr "بازی‌ها"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "افزودن بازی"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "درون‌ریزی"
 
@@ -168,8 +168,8 @@ msgstr "نمایش بازی‌های نهفته"
 msgid "Remove Game"
 msgstr "برداشتن بازی"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "رفتار"
 
@@ -185,7 +185,7 @@ msgstr "طرح جلد بازی را اجرا می‌کند"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "تغییر رفتار تصویر جلد و دکمهٔ بازی کردن"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "عکس‌ها"
 
@@ -201,137 +201,141 @@ msgstr "ذخیرهٔ طرح جلدهای بدون اتلاف به قیمت ذخ�
 msgid "Danger Zone"
 msgstr "منطقهٔ خطر"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "حذف کردن همهٔ بازی‌ها"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "برداشتن بازی‌های نصب‌نشده"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "منبع‌ها"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "استیم"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "مکان نصب"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "لوتریس"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "درون‌ریزی بازی‌های استیم"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "درون‌ریزی بازی‌های فلت‌پک"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "هروییک"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "درون‌ریزی بازی‌های اپیک"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "درون‌ریزی بازی‌های گوگ"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "درون‌ریزی بازی‌های آمازون"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "درون‌ریزی بازی‌های نصب‌شده"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "بطری‌ها"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "ایچ"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "لجندری"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "رتروآرچ"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "فلت‌پک"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "مکان سامانه"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "مکان کاربر"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "درون‌ریزی اجراگرهای بازی"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "ورودی‌های میزکار"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "هویت‌سنجی"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "کلید API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "استفاده از SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "بارگیری تصویرها هنگام افزودن یا درون‌ریزی بازی‌ها"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "ترجیح به تصویرهای رسمی"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "ترجیح تصویرهای پویا"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "به‌روزرسانی طرح جلد"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "دریافت طرح جلد بازی‌های کنونی کتاب‌خانه‌تان"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "به‌روزرسانی"
 
@@ -359,135 +363,136 @@ msgstr "بدون بازی نهفته"
 msgid "Games you hide will appear here"
 msgstr "بازی‌هایی که پنهان می‌کنید، این‌جا نمایان خواهند شد"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "همهٔ بازی‌ها"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "افزوده"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "درون‌ریخته"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "بازی‌های نهفته"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "عنوان بازی"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "بازی کردن"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "ترتیب"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "آ-ی"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "ی-آ"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "جدیدترین"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "قدیمی‌ترین"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "آخرین بازی‌شده"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "نمایش نهفته"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "دربارهٔ کارتریج‌ها"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} اجرا شد"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "دانیال بهزادی <dani.behzi@ubuntu.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "افزوده: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "هرگز"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "آخرین بازی‌شده: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "اعمال"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "افزودن بازی جدید"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "افزودن"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "اجرایی‌ها"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "پرونده.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "برنامه"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\Path\\to\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/path/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -509,19 +514,19 @@ msgstr ""
 "\n"
 "اگر مسیر فاصله داشت، مطمئن شوید در نقل‌قول گذاشته‌ایدش!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "نتوانست بازی بیفزاید"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "عنوان بازی نمی‌تواند خالی باشد."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "اجرایی نمی‌تواند خالی باشد."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "نتوانست ترجیحات را اعمال کند"
 
@@ -535,51 +540,50 @@ msgid "{} unhidden"
 msgstr "{} نانهفته"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} برداشته"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "همهٔ بازی‌ها برداشته شدند"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "برای استفاده از SteamGridDB نیاز به یک کلید API است. می‌توانید {}این‌جا{} یکی "
 "بسازید."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "در حال دریافت طرح‌های جلد…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "طرح‌های جلد به‌روزرسانی شد"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "نصب پیدا نشد"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "گزینش شاخه‌ای معتبر"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "هشدار"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "شاخهٔ نامعتبر"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "تنظیم مکان"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "رد"
 
@@ -587,27 +591,29 @@ msgstr "رد"
 msgid "Importing Games…"
 msgstr "درون‌ریزی بازی‌ها…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "هنگام درون‌ریزی خطاهای زیر رخ دادند:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "هیچ بازی جدیدی پیدا نشد"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "یک بازی درون‌ریخته شد"
+msgid_plural "{} games imported"
+msgstr[0] "یک بازی درون‌ریخته شد"
+msgstr[1] "{} بازی درون‌ریخته شدند"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} بازی درون‌ریخته شدند"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "یکی برداشته شد"
+msgid_plural "{} removed"
+msgstr[0] "یکی برداشته شد"
+msgstr[1] "{} برداشته شد"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -644,6 +650,9 @@ msgstr "نتوانست در SteamGridDB هویت‌سنجی کند"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "کلید APIتان را در ترجیحات تأیید کنید"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} بازی درون‌ریخته شدند"
 
 #~ msgid "Cache Location"
 #~ msgstr "مکان انباره"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/cartridges/"
@@ -545,9 +545,13 @@ msgid "{} unhidden"
 msgstr "{} palautettu näkyviin"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} poistettu"
+msgid_plural "{} removed"
+msgstr[0] "{} poistettu"
+msgstr[1] "{} poistettu"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -592,6 +596,32 @@ msgstr "Aseta sijainti"
 msgid "Dismiss"
 msgstr "Hylkää"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Tänään"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Eilen"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Viimeksi pelattu"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Viimeksi pelattu"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Tuodaan pelejä…"
@@ -607,18 +637,10 @@ msgstr "Uusia pelejä ei löytynyt"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 peli tuotu"
+msgstr[0] "{} peliä tuotu"
 msgstr[1] "{} peliä tuotu"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 poistettu"
-msgstr[1] "{} poistettu"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -656,8 +678,17 @@ msgstr "Ei voitu kirjautua SteamGridDB:hen"
 msgid "Verify your API key in preferences"
 msgstr "Vahvista API-avaimesi asetuksissa"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} peliä tuotu"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 peli tuotu"
+#~ msgstr[1] "{} peliä tuotu"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 poistettu"
+#~ msgstr[1] "{} poistettu"
 
 #~ msgid "Cache Location"
 #~ msgstr "Välimuistin sijainti"
@@ -728,12 +759,6 @@ msgstr "Vahvista API-avaimesi asetuksissa"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Bottles-asennuksen sijainti"
-
-#~ msgid "Today"
-#~ msgstr "Tänään"
-
-#~ msgid "Yesterday"
-#~ msgstr "Eilen"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Välimuistia ei löydy"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/cartridges/"
@@ -441,9 +441,8 @@ msgstr ""
 msgid "{} launched"
 msgstr "{} käynnistetty"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Linux Sauna"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/cartridges/"
@@ -68,7 +68,7 @@ msgstr "Muokkaa pelin tietoja"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Asetukset"
 
@@ -134,7 +134,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Pikanäppäimet"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Kumoa"
 
@@ -172,7 +172,7 @@ msgid "Remove Game"
 msgstr "Poista peli"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Toiminta"
 
@@ -208,139 +208,139 @@ msgstr "Vaaravyöhyke"
 msgid "Remove All Games"
 msgstr "Poista kaikki pelit"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Poista kaikki pelit, joiden asennus on poistettu"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Lähteet"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Asennuspaikka"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Tuo Steam-pelejä"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Tuo Flatpak-pelejä"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Tuo Epic-pelejä"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Tuo GOG-pelejä"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Tuo Amazon-pelejä"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Tuo Sideload-pelejä"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Pullot"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendaarinen"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 #, fuzzy
 msgid "System Location"
 msgstr "Aseta sijainti"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 #, fuzzy
 msgid "User Location"
 msgstr "Aseta sijainti"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Tuo pelin käynnistimet"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Työpöytätietueet"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-avain"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Käytä SteamGridDB:tä"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Lataa kuvia, kun lisäät tai tuot pelejä"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Mieluummin kuin virallisia kuvia"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Mieluummin animoituja kuvia"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Päivitä kannet"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Nouda kuoret jo kirjastossa oleville peleille"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Päivitä"
 
@@ -549,46 +549,46 @@ msgstr "{} palautettu näkyviin"
 msgid "{} removed"
 msgstr "{} poistettu"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Kaikki pelit poistettu"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB:n käyttäminen edellyttää API-avainta. Voit luoda sellaisen {}"
 "täältä{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Ladataan kansikuvia…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Kannet päivitetty"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Asennusta ei löydy"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Valitse kelvollinen kansio"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Varoitus"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Virheellinen kansio"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Aseta sijainti"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Hylkää"
 
@@ -596,16 +596,16 @@ msgstr "Hylkää"
 msgid "Importing Games…"
 msgstr "Tuodaan pelejä…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Seuraavat virheet tapahtuivat tuonnin aikana:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Uusia pelejä ei löytynyt"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -613,7 +613,7 @@ msgstr[0] "1 peli tuotu"
 msgstr[1] "{} peliä tuotu"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/cartridges/"
@@ -57,8 +57,8 @@ msgstr ""
 "Heroicista ja Bottlesista, sekä muistaa ilman kirjautumista. Voit lajitella "
 "tai piilottaa pelejä ja ladata kansikuvan SteamGridDB tietokannasta."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Pelin tiedot"
 
@@ -67,8 +67,8 @@ msgid "Edit Game Details"
 msgstr "Muokkaa pelin tietoja"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Asetukset"
 
@@ -76,47 +76,47 @@ msgstr "Asetukset"
 msgid "Cancel"
 msgstr "Peru"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Uusi kansi"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Poista kansi"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Nimi"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Kehittäjä (valinnainen)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Suoritettava"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Valitse tiedosto"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Lisätietoja"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Piilota"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Poista"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Näytä"
 
@@ -124,17 +124,17 @@ msgstr "Näytä"
 msgid "General"
 msgstr "Yleistä"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Etsi"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Pikanäppäimet"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Kumoa"
 
@@ -142,11 +142,11 @@ msgstr "Kumoa"
 msgid "Quit"
 msgstr "Lopeta"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Sivupalkki päälle/pois"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Päävalikko"
 
@@ -154,12 +154,12 @@ msgstr "Päävalikko"
 msgid "Games"
 msgstr "Pelit"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Lisää peli"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Tuo"
 
@@ -171,8 +171,8 @@ msgstr "Näytä piilotetut pelit"
 msgid "Remove Game"
 msgstr "Poista peli"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Toiminta"
 
@@ -188,7 +188,7 @@ msgstr "Kansikuva käynnistää pelin"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Vaihtaa keskenään kansikuvan ja Pelaa-painikkeen toiminnallisuuden"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Kuvat"
 
@@ -204,139 +204,143 @@ msgstr "Tallenna pelin kannet häviöttömästi tallennustilan kustannuksella."
 msgid "Danger Zone"
 msgstr "Vaaravyöhyke"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Poista kaikki pelit"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Poista kaikki pelit, joiden asennus on poistettu"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Lähteet"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Asennuspaikka"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Tuo Steam-pelejä"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Tuo Flatpak-pelejä"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Tuo Epic-pelejä"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Tuo GOG-pelejä"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Tuo Amazon-pelejä"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Tuo Sideload-pelejä"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Pullot"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendaarinen"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 #, fuzzy
 msgid "System Location"
 msgstr "Aseta sijainti"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 #, fuzzy
 msgid "User Location"
 msgstr "Aseta sijainti"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Tuo pelin käynnistimet"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Työpöytätietueet"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-avain"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Käytä SteamGridDB:tä"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Lataa kuvia, kun lisäät tai tuot pelejä"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Mieluummin kuin virallisia kuvia"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Mieluummin animoituja kuvia"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Päivitä kannet"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Nouda kuoret jo kirjastossa oleville peleille"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Päivitä"
 
@@ -364,135 +368,136 @@ msgstr "Ei piilotettuja pelejä"
 msgid "Games you hide will appear here"
 msgstr "Piilotetut pelit näkyvät täällä"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Kaikki pelit"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Lisätty"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Tuotu"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Piilotetut pelit"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Pelin nimi"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Pelaa"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Lajittele"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Uusin"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Vanhin"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Viimeksi pelattu"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Näytä piilotetut"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Tietoja - Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} käynnistetty"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Linux Sauna"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Lisätty: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Ei koskaan"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Viimeksi pelattu: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Käytä"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Lisää uusi peli"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Lisää"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Suoritettava"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "ohjelma"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\polku\\kansioon\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/polku/kansioon/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -515,19 +520,19 @@ msgstr ""
 "Jos polku sisältää välilyöntejä, varmista, että se on suljettu "
 "kaksinkertaisiin lainausmerkkeihin!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Peliä ei voitu lisätä"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Pelin nimi ei voi olla tyhjä."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Suoritettava ei voi olla tyhjä."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Asetuksia ei voitu ottaa käyttöön"
 
@@ -541,51 +546,50 @@ msgid "{} unhidden"
 msgstr "{} palautettu näkyviin"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} poistettu"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Kaikki pelit poistettu"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB:n käyttäminen edellyttää API-avainta. Voit luoda sellaisen {}"
 "täältä{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Ladataan kansikuvia…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Kannet päivitetty"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Asennusta ei löydy"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Valitse kelvollinen kansio"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Varoitus"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Virheellinen kansio"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Aseta sijainti"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Hylkää"
 
@@ -593,27 +597,29 @@ msgstr "Hylkää"
 msgid "Importing Games…"
 msgstr "Tuodaan pelejä…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Seuraavat virheet tapahtuivat tuonnin aikana:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Uusia pelejä ei löytynyt"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 peli tuotu"
+msgid_plural "{} games imported"
+msgstr[0] "1 peli tuotu"
+msgstr[1] "{} peliä tuotu"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} peliä tuotu"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 poistettu"
+msgid_plural "{} removed"
+msgstr[0] "1 poistettu"
+msgstr[1] "{} poistettu"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,6 +656,9 @@ msgstr "Ei voitu kirjautua SteamGridDB:hen"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Vahvista API-avaimesi asetuksissa"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} peliä tuotu"
 
 #~ msgid "Cache Location"
 #~ msgstr "Välimuistin sijainti"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-16 21:06+0000\n"
 "Last-Translator: \"J. Lavoie\" <j.lavoie@net-c.ca>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartridges/"
@@ -547,9 +547,13 @@ msgid "{} unhidden"
 msgstr "{} affiché"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} retiré"
+msgid_plural "{} removed"
+msgstr[0] "{} retiré"
+msgstr[1] "{} retiré"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -594,6 +598,32 @@ msgstr "Définir l’emplacement"
 msgid "Dismiss"
 msgstr "Fermer"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Aujourd’hui"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Hier"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Dernière session"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Dernière session"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importation des jeux…"
@@ -609,18 +639,10 @@ msgstr "Aucun nouveau jeu trouvé"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 jeu importé"
+msgstr[0] "{} jeux importés"
 msgstr[1] "{} jeux importés"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 retiré"
-msgstr[1] "{} retirés"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -658,8 +680,17 @@ msgstr "Impossible de se connecter à SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Vérifiez votre clé API dans les préférences"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} jeux importés"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 jeu importé"
+#~ msgstr[1] "{} jeux importés"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 retiré"
+#~ msgstr[1] "{} retirés"
 
 #~ msgid "Cache Location"
 #~ msgstr "Emplacement du cache"
@@ -724,12 +755,6 @@ msgstr "Vérifiez votre clé API dans les préférences"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Emplacement de l’installation de Bouteilles"
-
-#~ msgid "Today"
-#~ msgstr "Aujourd’hui"
-
-#~ msgid "Yesterday"
-#~ msgstr "Hier"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Cache non trouvé"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-16 21:06+0000\n"
 "Last-Translator: \"J. Lavoie\" <j.lavoie@net-c.ca>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartridges/"
@@ -441,11 +441,12 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} lancé"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
-msgstr "Irénée Thirion, L. Chareton"
+msgstr ""
+"Irénée Thirion\n"
+"L. Chareton"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-16 21:06+0000\n"
 "Last-Translator: \"J. Lavoie\" <j.lavoie@net-c.ca>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartridges/"
@@ -56,8 +56,8 @@ msgstr ""
 "encore, sans nécessiter de connexion. Vous pouvez trier et masquer les jeux "
 "ou télécharger la pochette depuis SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Détails du jeu"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Modifier les détails du jeu"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -75,47 +75,47 @@ msgstr "Préférences"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nouvelle couverture"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Supprimer la couverture"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titre"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Développeur (facultatif)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Exécutable"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Sélectionner un fichier"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Plus d’informations"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Modifier"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Masquer"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Supprimer"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Ne plus masquer"
 
@@ -123,17 +123,17 @@ msgstr "Ne plus masquer"
 msgid "General"
 msgstr "Général"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Rechercher"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Annuler"
 
@@ -141,11 +141,11 @@ msgstr "Annuler"
 msgid "Quit"
 msgstr "Quitter"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Afficher ou Cacher la Barre Latérale"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -153,12 +153,12 @@ msgstr "Menu principal"
 msgid "Games"
 msgstr "Jeux"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Ajouter un jeu"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importer"
 
@@ -170,8 +170,8 @@ msgstr "Afficher les jeux masqués"
 msgid "Remove Game"
 msgstr "Supprimer le jeu"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportement"
 
@@ -188,7 +188,7 @@ msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 "Intervertit le comportement de l’image de la pochette et du bouton de lecture"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Images"
 
@@ -206,137 +206,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Zone de danger"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Supprimer tous les jeux"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Retirer les jeux désinstallés"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Sources"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Emplacement d'installation"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importer les jeux de Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importer des jeux Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importer les jeux d'Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importer les jeux de GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importer les jeux Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importer des jeux Sideloaded"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bouteilles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Légendaire"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Emplacement du système"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Emplacement de l'utilisateur"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importer des lanceurs de jeux"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Éléments de bureau"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Authentification"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Clé API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Utiliser SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Télécharger les images lors de l’ajout ou de l’importation de jeux"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Préférer à la place des images officielles"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Préférer les images animées"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Mettre à jour les pochettes des jeux"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Récupérer les pochettes des jeux déjà présents dans votre bibliothèque"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Mise à jour"
 
@@ -364,135 +368,136 @@ msgstr "Pas de jeux masqués"
 msgid "Games you hide will appear here"
 msgstr "Les jeux que vous masquez apparaîtront ici"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Tous les Jeux"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Ajouté"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importé"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Jeux masqués"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Titre du jeu"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Jouer"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Trier"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Le plus récent"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Le plus ancien"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Dernière session"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Afficher les masqués"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "À propos de Cartouches"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} lancé"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Irénée Thirion, L. Chareton"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Ajouté : {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Jamais"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Dernière session : {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Appliquer"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Ajouter un nouveau jeu"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Ajouter"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Exécutables"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "fichier.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programme"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\chemin\\vers\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/chemin/vers/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -515,19 +520,19 @@ msgstr ""
 "Si le chemin d'accès contient des espaces, veillez à le mettre entre "
 "guillemets !"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Impossible d’ajouter le jeu"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Le titre du jeu ne peut pas être vide."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "L’exécutable ne peut pas être vide."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Impossible d’appliquer les préférences"
 
@@ -541,51 +546,50 @@ msgid "{} unhidden"
 msgstr "{} affiché"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} retiré"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Tous les jeux ont été supprimés"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Une clé API est requise pour utiliser SteamGridDB. Vous pouvez en générer "
 "une {}ici{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Téléchargement des pochettes des jeux…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Couvertures des jeux mises à jour"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installation introuvable"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Sélectionnez un répertoire valide"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Attention"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Répertoire invalide"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Définir l’emplacement"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Fermer"
 
@@ -593,27 +597,29 @@ msgstr "Fermer"
 msgid "Importing Games…"
 msgstr "Importation des jeux…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Les erreurs suivantes se sont produites durant l'importation :"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Aucun nouveau jeu trouvé"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 jeu importé"
+msgid_plural "{} games imported"
+msgstr[0] "1 jeu importé"
+msgstr[1] "{} jeux importés"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} jeux importés"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 retiré"
+msgid_plural "{} removed"
+msgstr[0] "1 retiré"
+msgstr[1] "{} retirés"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,6 +656,9 @@ msgstr "Impossible de se connecter à SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Vérifiez votre clé API dans les préférences"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} jeux importés"
 
 #~ msgid "Cache Location"
 #~ msgstr "Emplacement du cache"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-16 21:06+0000\n"
 "Last-Translator: \"J. Lavoie\" <j.lavoie@net-c.ca>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartridges/"
@@ -67,7 +67,7 @@ msgstr "Modifier les détails du jeu"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Annuler"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Supprimer le jeu"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportement"
 
@@ -210,137 +210,137 @@ msgstr "Zone de danger"
 msgid "Remove All Games"
 msgstr "Supprimer tous les jeux"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Retirer les jeux désinstallés"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Sources"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Emplacement d'installation"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importer les jeux de Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importer des jeux Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importer les jeux d'Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importer les jeux de GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importer les jeux Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importer des jeux Sideloaded"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bouteilles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Légendaire"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Emplacement du système"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Emplacement de l'utilisateur"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importer des lanceurs de jeux"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Éléments de bureau"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Authentification"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Clé API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Utiliser SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Télécharger les images lors de l’ajout ou de l’importation de jeux"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Préférer à la place des images officielles"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Préférer les images animées"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Mettre à jour les pochettes des jeux"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Récupérer les pochettes des jeux déjà présents dans votre bibliothèque"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Mise à jour"
 
@@ -551,46 +551,46 @@ msgstr "{} affiché"
 msgid "{} removed"
 msgstr "{} retiré"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Tous les jeux ont été supprimés"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Une clé API est requise pour utiliser SteamGridDB. Vous pouvez en générer "
 "une {}ici{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Téléchargement des pochettes des jeux…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Couvertures des jeux mises à jour"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installation introuvable"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Sélectionnez un répertoire valide"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Attention"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Répertoire invalide"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Définir l’emplacement"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Fermer"
 
@@ -598,16 +598,16 @@ msgstr "Fermer"
 msgid "Importing Games…"
 msgstr "Importation des jeux…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Les erreurs suivantes se sont produites durant l'importation :"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Aucun nouveau jeu trouvé"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -615,7 +615,7 @@ msgstr[0] "1 jeu importé"
 msgstr[1] "{} jeux importés"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-05-07 09:07+0000\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/cartridges/"
@@ -434,9 +434,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} लॉन्च किया गया"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Scrambled777 <weblate.scrambled777@simplelogin.com>"
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-05-07 09:07+0000\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/cartridges/"
@@ -537,9 +537,13 @@ msgid "{} unhidden"
 msgstr "{} नहीं छिपा हुआ"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} हटाया हुआ"
+msgid_plural "{} removed"
+msgstr[0] "{} हटाया हुआ"
+msgstr[1] "{} हटाया हुआ"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -584,6 +588,32 @@ msgstr "स्थान तय करें"
 msgid "Dismiss"
 msgstr "खारिज करें"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "अंतिम बार खेला गया"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "अंतिम बार खेला गया"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "गेम्स आयात किया जा रहा है…"
@@ -599,18 +629,10 @@ msgstr "कोई नया गेम्स नहीं मिले"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 गेम आयात किया गया"
+msgstr[0] "{} गेम्स आयातित"
 msgstr[1] "{} गेम्स आयातित"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 हटाया गया"
-msgstr[1] "{} हटाया गया"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -648,8 +670,17 @@ msgstr "SteamGridDB को प्रमाणित नहीं किया �
 msgid "Verify your API key in preferences"
 msgstr "प्राथमिकताओं में अपनी API कुंजी सत्यापित करें"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} गेम्स आयातित"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 गेम आयात किया गया"
+#~ msgstr[1] "{} गेम्स आयातित"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 हटाया गया"
+#~ msgstr[1] "{} हटाया गया"
 
 #~ msgid "Cache Location"
 #~ msgstr "कैशे की जगह"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-05-07 09:07+0000\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/cartridges/"
@@ -52,8 +52,8 @@ msgstr ""
 "Steam, Lutris, Heroic और अन्य से गेम आयात करने का समर्थन है। आप गेम को सॉर्ट और छिपा "
 "सकते हैं या SteamGridDB से कवर आर्ट डाउनलोड कर सकते हैं।"
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "गेम विवरण"
 
@@ -62,8 +62,8 @@ msgid "Edit Game Details"
 msgstr "गेम विवरण संपादन"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "प्राथमिकताएं"
 
@@ -71,47 +71,47 @@ msgstr "प्राथमिकताएं"
 msgid "Cancel"
 msgstr "रद्द करें"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "नया कवर"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "कवर मिटाएं"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "शीर्षक"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "विकासकर्ता (वैकल्पिक)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "निष्पादनयोग्य"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "फाइल चुनें"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "अधिक जानकारी"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "संपादन"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "छुपाएं"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "हटाएं"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "सामने लाएं"
 
@@ -119,17 +119,17 @@ msgstr "सामने लाएं"
 msgid "General"
 msgstr "सामान्य"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "खोजें"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "कीबोर्ड शॉर्टकट"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "पूर्ववत करें"
 
@@ -137,11 +137,11 @@ msgstr "पूर्ववत करें"
 msgid "Quit"
 msgstr "छोड़ें"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "पार्श्वपट्टी टॉगल करें"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "मुख्य मेनू"
 
@@ -149,12 +149,12 @@ msgstr "मुख्य मेनू"
 msgid "Games"
 msgstr "गेम्स"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "गेम जोड़ें"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "आयात"
 
@@ -166,8 +166,8 @@ msgstr "छिपे हुए गेम्स दिखाएं"
 msgid "Remove Game"
 msgstr "गेम हटाएं"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "व्यवहार"
 
@@ -183,7 +183,7 @@ msgstr "कवर छवि गेम लॉन्च करती है"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "कवर छवि और प्ले बटन के व्यवहार की अदला-बदली करता है"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "छवियां"
 
@@ -199,137 +199,141 @@ msgstr "स्टोरेज की कीमत पर हानि रहि�
 msgid "Danger Zone"
 msgstr "खतरनाक क्षेत्र"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "सभी गेम्स हटाएं"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "अस्थापित गेम्स हटाएं"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "स्रोत"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "इंस्टॉल जगह"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "साइडलोडेड गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "सिस्टम की जगह"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "उपयोगकर्ता की जगह"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "गेम लॉन्चर आयात करें"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "डेस्कटॉप प्रविष्टियां"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "प्रमाणीकरण"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API कुंजी"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB का प्रयोग करें"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "गेम जोड़ते या आयात करते समय छवियां डाउनलोड करें"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "आधिकारिक छवियों से अधिक प्राथमिकता दें"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "सजीव छवियों को प्राथमिकता दें"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "कवर अद्यतन करें"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "अपनी लाइब्रेरी में पहले से ही गेम के लिए कवर प्राप्त करें"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "अद्यतन"
 
@@ -357,135 +361,136 @@ msgstr "कोई छुपे गेम्स नहीं"
 msgid "Games you hide will appear here"
 msgstr "आपके द्वारा छिपाए गए गेम यहां दिखाई देंगे"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "सभी गेम्स"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "जोड़ा गया"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "आयातित"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "छुपे हुए गेम्स"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "गेम शीर्षक"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "खेलें"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "क्रमबद्ध करें"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "नवीनतम"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "सबसे पुराने"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "अंतिम बार खेला गया"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "छुपे हुआ दिखाएं"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Cartridges के बारे में"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} लॉन्च किया गया"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Scrambled777 <weblate.scrambled777@simplelogin.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "जोड़ा गया: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "कभी नहीं"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "अंतिम बार खेला गया: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "लागू करें"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "नया गेम जोड़ें"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "जोड़ें"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "निष्पादनयोग्य"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "फाइल.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "प्रोग्राम"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\पथ\\को\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/पथ/को/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -505,22 +510,21 @@ msgstr ""
 "\n"
 "<tt>{} \"{}\"</tt>\n"
 "\n"
-"यदि पथ में रिक्त स्थान हैं, तो इसे दोहरे उद्धरण चिह्नों में लपेटना सुनिश्चित "
-"करें!"
+"यदि पथ में रिक्त स्थान हैं, तो इसे दोहरे उद्धरण चिह्नों में लपेटना सुनिश्चित करें!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "गेम नहीं जोड़ा जा सका"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "गेम का शीर्षक रिक्त नहीं हो सकता।"
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "निष्पादनयोग्य खाली नहीं हो सकता।"
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "प्राथमिकताएं लागू नहीं की जा सकी"
 
@@ -534,51 +538,50 @@ msgid "{} unhidden"
 msgstr "{} नहीं छिपा हुआ"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} हटाया हुआ"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "सभी गेम्स हटा दिए गए"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB का उपयोग करने के लिए API कुंजी की आवश्यकता होती है। आप {}यहां{} एक "
 "उत्पन्न कर सकते हैं।"
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "कवर डाउनलोड हो रहा है…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "कवर अद्यतित"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "इंस्टालेशन नहीं मिला"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "एक मान्य निर्देशिका चुनें"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "चेतावनी"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "अमान्य निर्देशिका"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "स्थान तय करें"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "खारिज करें"
 
@@ -586,27 +589,29 @@ msgstr "खारिज करें"
 msgid "Importing Games…"
 msgstr "गेम्स आयात किया जा रहा है…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "आयात के दौरान निम्नलिखित त्रुटियां हुईं:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "कोई नया गेम्स नहीं मिले"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 गेम आयात किया गया"
+msgid_plural "{} games imported"
+msgstr[0] "1 गेम आयात किया गया"
+msgstr[1] "{} गेम्स आयातित"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} गेम्स आयातित"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 हटाया गया"
+msgid_plural "{} removed"
+msgstr[0] "1 हटाया गया"
+msgstr[1] "{} हटाया गया"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -643,6 +648,9 @@ msgstr "SteamGridDB को प्रमाणित नहीं किया �
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "प्राथमिकताओं में अपनी API कुंजी सत्यापित करें"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} गेम्स आयातित"
 
 #~ msgid "Cache Location"
 #~ msgstr "कैशे की जगह"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-05-07 09:07+0000\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/cartridges/"
@@ -63,7 +63,7 @@ msgstr "गेम विवरण संपादन"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "प्राथमिकताएं"
 
@@ -129,7 +129,7 @@ msgid "Keyboard Shortcuts"
 msgstr "कीबोर्ड शॉर्टकट"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "पूर्ववत करें"
 
@@ -167,7 +167,7 @@ msgid "Remove Game"
 msgstr "गेम हटाएं"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "व्यवहार"
 
@@ -203,137 +203,137 @@ msgstr "खतरनाक क्षेत्र"
 msgid "Remove All Games"
 msgstr "सभी गेम्स हटाएं"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "अस्थापित गेम्स हटाएं"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "स्रोत"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "इंस्टॉल जगह"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "साइडलोडेड गेम्स आयात करें"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "सिस्टम की जगह"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "उपयोगकर्ता की जगह"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "गेम लॉन्चर आयात करें"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "डेस्कटॉप प्रविष्टियां"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "प्रमाणीकरण"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API कुंजी"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB का प्रयोग करें"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "गेम जोड़ते या आयात करते समय छवियां डाउनलोड करें"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "आधिकारिक छवियों से अधिक प्राथमिकता दें"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "सजीव छवियों को प्राथमिकता दें"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "कवर अद्यतन करें"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "अपनी लाइब्रेरी में पहले से ही गेम के लिए कवर प्राप्त करें"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "अद्यतन"
 
@@ -541,46 +541,46 @@ msgstr "{} नहीं छिपा हुआ"
 msgid "{} removed"
 msgstr "{} हटाया हुआ"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "सभी गेम्स हटा दिए गए"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB का उपयोग करने के लिए API कुंजी की आवश्यकता होती है। आप {}यहां{} एक "
 "उत्पन्न कर सकते हैं।"
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "कवर डाउनलोड हो रहा है…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "कवर अद्यतित"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "इंस्टालेशन नहीं मिला"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "एक मान्य निर्देशिका चुनें"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "चेतावनी"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "अमान्य निर्देशिका"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "स्थान तय करें"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "खारिज करें"
 
@@ -588,16 +588,16 @@ msgstr "खारिज करें"
 msgid "Importing Games…"
 msgstr "गेम्स आयात किया जा रहा है…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "आयात के दौरान निम्नलिखित त्रुटियां हुईं:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "कोई नया गेम्स नहीं मिले"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -605,7 +605,7 @@ msgstr[0] "1 गेम आयात किया गया"
 msgstr[1] "{} गेम्स आयातित"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-23 17:07+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/cartridges/"
@@ -539,9 +539,14 @@ msgid "{} unhidden"
 msgstr "Prikazano: {}"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "Uklonjeno: {}"
+msgid_plural "{} removed"
+msgstr[0] "Uklonjeno: {}"
+msgstr[1] "Uklonjeno: {}"
+msgstr[2] "Uklonjeno: {}"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -586,6 +591,32 @@ msgstr "Postavi lokaciju"
 msgid "Dismiss"
 msgstr "Odbaci"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Zadnje igrane"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Zadnje igrane"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Uvoz igri …"
@@ -601,20 +632,11 @@ msgstr "Nije pronađena nijedna nova igra"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "Jedna igra je uvezena"
+msgstr[0] "Broj uvezenih igri: {}"
 msgstr[1] "Broj uvezenih igri: {}"
 msgstr[2] "Broj uvezenih igri: {}"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "Jedna je uklonjena"
-msgstr[1] "{} je uklonjena"
-msgstr[2] "{} je uklonjena"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -652,8 +674,19 @@ msgstr "Neuspjela autentifikacija SteamGridDB-a"
 msgid "Verify your API key in preferences"
 msgstr "Potvrdi tvoj API ključ u postavkama"
 
-#~ msgid "{} games imported"
-#~ msgstr "Broj uvezenih igri: {}"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "Jedna igra je uvezena"
+#~ msgstr[1] "Broj uvezenih igri: {}"
+#~ msgstr[2] "Broj uvezenih igri: {}"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "Jedna je uklonjena"
+#~ msgstr[1] "{} je uklonjena"
+#~ msgstr[2] "{} je uklonjena"
 
 #~ msgid "Cache Location"
 #~ msgstr "Lokacija predmemorije"

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-23 17:07+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/cartridges/"
@@ -436,9 +436,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "Pokrenuto: {}"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-23 17:07+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "Uredi detalje igre"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Postavke"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Tipkovnički prečaci"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Poništi"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "Ukloni igru"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Ponašanje"
 
@@ -205,137 +205,137 @@ msgstr "Opasno područje"
 msgid "Remove All Games"
 msgstr "Ukloni sve igre"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Ukloni deinstalirane igre"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Izvori"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Instaliraj lokaciju"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Uvezi Steam igre"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Uvezi Flatpak igre"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Uvezi Epic igre"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Uvezi GOG igre"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Uvezi Amazon igre"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Uvezi Sideloaded igre"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Butelje"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Lokacija sustava"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Lokacija korisnika"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Uvezi pokretače igri"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop unosi"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autentifikacija"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API Ključ"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Koristi SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Preuzmi slike prilikom dodavanja ili uvoza igri"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferiraj službene slike"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferiraj animirane slike"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Aktualiziraj naslovnice"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Preuzmi naslovnice za igre koje se već nalaze u tvojoj knjižnici"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Aktualizirati"
 
@@ -543,46 +543,46 @@ msgstr "Prikazano: {}"
 msgid "{} removed"
 msgstr "Uklonjeno: {}"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Sve igre su uklonjene"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Za korištenje SteamGridDB-a je potreban API ključ. Možeš ga generirati {}"
 "ovdje{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Preuzimanje naslovnica …"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Naslovnice su aktualizirane"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalacija nije pronađena"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Odaberi jedan valjani direktorij"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Upozorenje"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Nevaljani direktorij"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Postavi lokaciju"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Odbaci"
 
@@ -590,16 +590,16 @@ msgstr "Odbaci"
 msgid "Importing Games…"
 msgstr "Uvoz igri …"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Dogodile su se sljedeće greške tijekom uvoza:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nije pronađena nijedna nova igra"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -608,7 +608,7 @@ msgstr[1] "Broj uvezenih igri: {}"
 msgstr[2] "Broj uvezenih igri: {}"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-23 17:07+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "promijeniti redoslijed igri, sakriti igre ili preuzeti naslovnice sa "
 "SteamGridDB-a."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalji igre"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "Uredi detalje igre"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Postavke"
 
@@ -73,47 +73,47 @@ msgstr "Postavke"
 msgid "Cancel"
 msgstr "Otkaži"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nova naslovnica"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Izbriši naslovnicu"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Naslov"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Programer (opcijonalno)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Izvršna datoteka"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Odaberi datoteku"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Daljnje informacije"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Uredi"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Sakrij"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Ukloni"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Prikaži"
 
@@ -121,17 +121,17 @@ msgstr "Prikaži"
 msgid "General"
 msgstr "Općenito"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Traži"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Tipkovnički prečaci"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Poništi"
 
@@ -139,11 +139,11 @@ msgstr "Poništi"
 msgid "Quit"
 msgstr "Zatvori aplikaciju"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Uključi/Isključi bočnu traku"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Glavni izbornik"
 
@@ -151,12 +151,12 @@ msgstr "Glavni izbornik"
 msgid "Games"
 msgstr "Igre"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Dodaj igru"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Uvezi"
 
@@ -168,8 +168,8 @@ msgstr "Prikaži skrivene igre"
 msgid "Remove Game"
 msgstr "Ukloni igru"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Ponašanje"
 
@@ -185,7 +185,7 @@ msgstr "Slika naslovnice pokreće igru"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Mijenja ponašanje slike naslovnice i gumba za pokretanje igre"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Slike"
 
@@ -201,137 +201,141 @@ msgstr "Spremi nalsovnice igri bez gubitka kvalitete nauštrb memorije"
 msgid "Danger Zone"
 msgstr "Opasno područje"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Ukloni sve igre"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Ukloni deinstalirane igre"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Izvori"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Instaliraj lokaciju"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Uvezi Steam igre"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Uvezi Flatpak igre"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Uvezi Epic igre"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Uvezi GOG igre"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Uvezi Amazon igre"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Uvezi Sideloaded igre"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Butelje"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Lokacija sustava"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Lokacija korisnika"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Uvezi pokretače igri"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Desktop unosi"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autentifikacija"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API Ključ"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Koristi SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Preuzmi slike prilikom dodavanja ili uvoza igri"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferiraj službene slike"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Preferiraj animirane slike"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Aktualiziraj naslovnice"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Preuzmi naslovnice za igre koje se već nalaze u tvojoj knjižnici"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Aktualizirati"
 
@@ -359,135 +363,136 @@ msgstr "Nema skrivenih igri"
 msgid "Games you hide will appear here"
 msgstr "Igre koje sakriješ će se pojaviti ovdje"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Sve igre"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Dodano"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Uvezeno"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Skrivene igre"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Naslov igre"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Igraj"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Redoslijed"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Najnovije"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Najstarije"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Zadnje igrane"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Prikaži skrivene"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Informacije o Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "Pokrenuto: {}"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Dodano: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nikada"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Zadnje igrane: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Primijeni"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Dodaj novu igru"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Dodaj"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Izvršne datoteke"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "datoteka.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\putanja\\do\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "\\putanja\\do\\{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -509,19 +514,19 @@ msgstr ""
 "\n"
 "Ako putanja sadrži razmake, obavezno je stavi u navodnike!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Neuspjelo dodavanje igre"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Naslov igre ne može biti prazan."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Izvršna datoteka ne može biti prazna."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Neuspjela primjena postavki"
 
@@ -535,51 +540,50 @@ msgid "{} unhidden"
 msgstr "Prikazano: {}"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "Uklonjeno: {}"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Sve igre su uklonjene"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Za korištenje SteamGridDB-a je potreban API ključ. Možeš ga generirati {}"
 "ovdje{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Preuzimanje naslovnica …"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Naslovnice su aktualizirane"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Instalacija nije pronađena"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Odaberi jedan valjani direktorij"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Upozorenje"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Nevaljani direktorij"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Postavi lokaciju"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Odbaci"
 
@@ -587,27 +591,31 @@ msgstr "Odbaci"
 msgid "Importing Games…"
 msgstr "Uvoz igri …"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Dogodile su se sljedeće greške tijekom uvoza:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nije pronađena nijedna nova igra"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "Jedna igra je uvezena"
+msgid_plural "{} games imported"
+msgstr[0] "Jedna igra je uvezena"
+msgstr[1] "Broj uvezenih igri: {}"
+msgstr[2] "Broj uvezenih igri: {}"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "Broj uvezenih igri: {}"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "Jedna je uklonjena"
+msgid_plural "{} removed"
+msgstr[0] "Jedna je uklonjena"
+msgstr[1] "{} je uklonjena"
+msgstr[2] "{} je uklonjena"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -644,6 +652,9 @@ msgstr "Neuspjela autentifikacija SteamGridDB-a"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Potvrdi tvoj API ključ u postavkama"
+
+#~ msgid "{} games imported"
+#~ msgstr "Broj uvezenih igri: {}"
 
 #~ msgid "Cache Location"
 #~ msgstr "Lokacija predmemorije"

--- a/po/hu.po
+++ b/po/hu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-03-23 19:56+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@mailbox.org>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/cartridges/"
@@ -55,8 +55,8 @@ msgstr ""
 "Rendezheti és elrejtheti a játékait, valamint letölthet borítóképeket a "
 "SteamGridDB-ről."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Játék tulajdonságai"
 
@@ -65,8 +65,8 @@ msgid "Edit Game Details"
 msgstr "Játék szerkesztése"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Beállítások"
 
@@ -74,47 +74,47 @@ msgstr "Beállítások"
 msgid "Cancel"
 msgstr "Mégse"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Új borító"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Borító törlése"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Cím"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Fejlesztő (nem kötelező)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Program"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Fájl kiválasztása"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "További információk"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Elrejtés"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Elrejtés visszavonása"
 
@@ -122,17 +122,17 @@ msgstr "Elrejtés visszavonása"
 msgid "General"
 msgstr "Általános"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Keresés"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Gyorsbillentyűk"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Visszavonás"
 
@@ -140,11 +140,11 @@ msgstr "Visszavonás"
 msgid "Quit"
 msgstr "Kilépés"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Oldalsáv megjelenítése"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Főmenü"
 
@@ -152,12 +152,12 @@ msgstr "Főmenü"
 msgid "Games"
 msgstr "Játékok"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Játék hozzáadása"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importálás"
 
@@ -169,8 +169,8 @@ msgstr "Rejtett játékok megjelenítése"
 msgid "Remove Game"
 msgstr "Játék eltávolítása"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Működés"
 
@@ -186,7 +186,7 @@ msgstr "A borítókép indítja el a játékot"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Felcseréli a „Játék” gomb és a borítókép funkcióját"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Képek"
 
@@ -202,137 +202,141 @@ msgstr "Játékborítók veszteségmentes tárolása a tárhely költségére"
 msgid "Danger Zone"
 msgstr "Veszélyzóna"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Az összes játék eltávolítása"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Nem található játékok eltávolítása"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Források"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Telepítés helye"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam játékok importálása"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak játékok importálása"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic Games játékok importálása"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG játékok importálása"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon játékok importálása"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Kézileg hozzáadott játékok importálása"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Palackok"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Rendszermappa helye"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Felhasználói mappa helye"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Játékindítók importálása"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Asztali bejegyzések"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Hitelesítés"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-kulcs"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB használata"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Képek letöltése a játékok hozzáadásakor és importálásakor"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "A SteamGridDB-ből származó képek előnyben részesítése"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Animált képek előnyben részesítése"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Borítók frissítése"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Borítók letöltése játékokhoz, amik már a könyvtárában vannak"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Frissítés"
 
@@ -360,135 +364,136 @@ msgstr "Nincsenek rejtett játékok"
 msgid "Games you hide will appear here"
 msgstr "A rejtett játékok itt fognak megjelenni"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Összes játék"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Hozzáadva"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importálva"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Rejtett játékok"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Cím"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Játék"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Rendezés"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A–Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z–A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Legújabb"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Legrégebbi"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Legutóbb játszott"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Rejtett játékok"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "A Kazetták névjegye"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} elindítva"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Meskó Balázs <mesko dot balazs at fsf dot hu>, 2024."
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Hozzáadva: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Soha"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Legutóbb játszva: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Alkalmazás"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Új játék hozzáadása"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Programok"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "fájl.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\útvonal\\ide\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/útvonal/ide/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -511,19 +516,19 @@ msgstr ""
 "\n"
 "Ha az elérési útvonalban szóközök vannak, rakja az útvonalat idézőjelek közé!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Nem lehet hozzáadni a játékot"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "A cím nem lehet üres."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "A program nem lehet üres."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Nem lehet menteni a beállításokat"
 
@@ -537,51 +542,50 @@ msgid "{} unhidden"
 msgstr "{} elrejtése visszavonva"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} eltávolítva"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Az összes játék eltávolítva"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Egy API-kulcs szükséges a SteamGridDB használatához. {}Itt{} állíthat elő "
 "egyet."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Borítóképek letöltése…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Borítóképek frissítve"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "A telepítés nem található"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Válasszon egy érvényes mappát"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Érvénytelen mappa"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Hely megadása"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Eltüntetés"
 
@@ -589,27 +593,29 @@ msgstr "Eltüntetés"
 msgid "Importing Games…"
 msgstr "Játékok importálása…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "A következő hibák történtek importálás közben:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nem találhatóak új játékok"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 játék importálva"
+msgid_plural "{} games imported"
+msgstr[0] "1 játék importálva"
+msgstr[1] "{} játék importálva"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} játék importálva"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 eltávolítva"
+msgid_plural "{} removed"
+msgstr[0] "1 eltávolítva"
+msgstr[1] "{} eltávolítva"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -646,6 +652,9 @@ msgstr "A SteamGridDB-hitelesítés nem sikerült"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Ellenőrizze az API-kulcsát a beállításokban"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} játék importálva"
 
 #~ msgid "kramo"
 #~ msgstr "kramo"

--- a/po/hu.po
+++ b/po/hu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-10-22 10:56+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@mailbox.org>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/cartridges/"
@@ -541,9 +541,13 @@ msgid "{} unhidden"
 msgstr "{} elrejtése visszavonva"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} eltávolítva"
+msgid_plural "{} removed"
+msgstr[0] "{} eltávolítva"
+msgstr[1] "{} eltávolítva"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -588,6 +592,32 @@ msgstr "Hely megadása"
 msgid "Dismiss"
 msgstr "Eltüntetés"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Ma"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Tegnap"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Legutóbb játszott"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Legutóbb játszott"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Játékok importálása…"
@@ -603,18 +633,10 @@ msgstr "Nem találhatóak új játékok"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 játék importálva"
+msgstr[0] "{} játék importálva"
 msgstr[1] "{} játék importálva"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 eltávolítva"
-msgstr[1] "{} eltávolítva"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -652,8 +674,17 @@ msgstr "A SteamGridDB-hitelesítés nem sikerült"
 msgid "Verify your API key in preferences"
 msgstr "Ellenőrizze az API-kulcsát a beállításokban"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} játék importálva"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 játék importálva"
+#~ msgstr[1] "{} játék importálva"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 eltávolítva"
+#~ msgstr[1] "{} eltávolítva"
 
 #~ msgid "kramo"
 #~ msgstr "kramo"
@@ -730,12 +761,6 @@ msgstr "Ellenőrizze az API-kulcsát a beállításokban"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Palackok telepítés helye"
-
-#~ msgid "Today"
-#~ msgstr "Ma"
-
-#~ msgid "Yesterday"
-#~ msgstr "Tegnap"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Gyorsítótár nem található"

--- a/po/hu.po
+++ b/po/hu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-03-23 19:56+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@mailbox.org>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/cartridges/"
@@ -437,11 +437,10 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} elindítva"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
-msgstr "Meskó Balázs <mesko dot balazs at fsf dot hu>, 2024."
+msgstr "Meskó Balázs <mesko.balazs@fsf.hu>"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/hu.po
+++ b/po/hu.po
@@ -9,9 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
-"PO-Revision-Date: 2024-03-23 19:56+0000\n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-10-22 10:56+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@mailbox.org>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/cartridges/"
@@ -68,7 +66,7 @@ msgstr "Játék szerkesztése"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Beállítások"
 
@@ -134,7 +132,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Gyorsbillentyűk"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Visszavonás"
 
@@ -172,7 +170,7 @@ msgid "Remove Game"
 msgstr "Játék eltávolítása"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Működés"
 
@@ -208,137 +206,137 @@ msgstr "Veszélyzóna"
 msgid "Remove All Games"
 msgstr "Az összes játék eltávolítása"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Nem található játékok eltávolítása"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Források"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Telepítés helye"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam játékok importálása"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak játékok importálása"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic Games játékok importálása"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG játékok importálása"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon játékok importálása"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Kézileg hozzáadott játékok importálása"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Rendszermappa helye"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Felhasználói mappa helye"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Játékindítók importálása"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Asztali bejegyzések"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Hitelesítés"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-kulcs"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB használata"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Képek letöltése a játékok hozzáadásakor és importálásakor"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "A SteamGridDB-ből származó képek előnyben részesítése"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Animált képek előnyben részesítése"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Borítók frissítése"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Borítók letöltése játékokhoz, amik már a könyvtárában vannak"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Frissítés"
 
@@ -547,46 +545,46 @@ msgstr "{} elrejtése visszavonva"
 msgid "{} removed"
 msgstr "{} eltávolítva"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Az összes játék eltávolítva"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Egy API-kulcs szükséges a SteamGridDB használatához. {}Itt{} állíthat elő "
 "egyet."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Borítóképek letöltése…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Borítóképek frissítve"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "A telepítés nem található"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Válasszon egy érvényes mappát"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Érvénytelen mappa"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Hely megadása"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Eltüntetés"
 
@@ -594,16 +592,16 @@ msgstr "Eltüntetés"
 msgid "Importing Games…"
 msgstr "Játékok importálása…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "A következő hibák történtek importálás közben:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nem találhatóak új játékok"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -611,7 +609,7 @@ msgstr[0] "1 játék importálva"
 msgstr[1] "{} játék importálva"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ie.po
+++ b/po/ie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-09-13 15:09+0000\n"
 "Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
 "Language-Team: Occidental <https://hosted.weblate.org/projects/cartridges/"
@@ -433,11 +433,10 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} ea lansat"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
-msgstr "OIS <mistresssilvara@hotmail.com>, 2024"
+msgstr "OIS <mistresssilvara@hotmail.com>"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/ie.po
+++ b/po/ie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-09-13 15:09+0000\n"
 "Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
 "Language-Team: Occidental <https://hosted.weblate.org/projects/cartridges/"
@@ -62,7 +62,7 @@ msgstr "Redacter li detallies del lude"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferenties"
 
@@ -128,7 +128,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Rapid-tastes"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Defar"
 
@@ -166,7 +166,7 @@ msgid "Remove Game"
 msgstr "Remover li lude"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Conduida"
 
@@ -202,137 +202,137 @@ msgstr ""
 msgid "Remove All Games"
 msgstr "Remover omni ludes"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Remover desinstallat ludes"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Orígines"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Localisation de installation"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importar ludes de Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importar ludes Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importar ludes de Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importar ludes de GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importar ludes de Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Botelles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Localisation del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Localisation del usator"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importar lansatores de ludes"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Files desktop"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autentication"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Clave de API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Descargar images quande on adjunte o importa ludes"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Actualisar covrimentes"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Obtener covrimentes por ludes in vor biblioteca"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Actualisar"
 
@@ -540,45 +540,45 @@ msgstr "{} revelat"
 msgid "{} removed"
 msgstr "{} sta removet"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Omni ludes sta removet"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Un clave de API es besonat por SteamGridDB. Vu posse generar ún {}ci ti{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Descarga de covrimentes…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Li covrimentes sta actualisat"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installation ne es trovat"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Ples selecter un valid categorie"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Avise"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Ínvalid fólder"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Assignar li localisation"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Demisser"
 
@@ -586,16 +586,16 @@ msgstr "Demisser"
 msgid "Importing Games…"
 msgstr "Importation de ludes…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Li sequent errorees evenit durante li importation:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Null nov ludes trovat"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -603,7 +603,7 @@ msgstr[0] "1 lude sta importat"
 msgstr[1] "{} ludes sta importat"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ie.po
+++ b/po/ie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-09-13 15:09+0000\n"
 "Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
 "Language-Team: Occidental <https://hosted.weblate.org/projects/cartridges/"
@@ -536,9 +536,13 @@ msgid "{} unhidden"
 msgstr "{} revelat"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} sta removet"
+msgid_plural "{} removed"
+msgstr[0] "{} sta removet"
+msgstr[1] "{} sta removet"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -582,6 +586,32 @@ msgstr "Assignar li localisation"
 msgid "Dismiss"
 msgstr "Demisser"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Ludet"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Ludet"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importation de ludes…"
@@ -597,18 +627,10 @@ msgstr "Null nov ludes trovat"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 lude sta importat"
+msgstr[0] "{} ludes sta importat"
 msgstr[1] "{} ludes sta importat"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 removet"
-msgstr[1] "{} removet"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -646,5 +668,14 @@ msgstr "Autentication ínvalid de SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Ples controlar vor clave de API in li preferenties"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} ludes sta importat"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 lude sta importat"
+#~ msgstr[1] "{} ludes sta importat"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 removet"
+#~ msgstr[1] "{} removet"

--- a/po/ie.po
+++ b/po/ie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-09-13 15:09+0000\n"
 "Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
 "Language-Team: Occidental <https://hosted.weblate.org/projects/cartridges/"
@@ -51,8 +51,8 @@ msgstr ""
 "ludes de Steam, Lutris, Heroic e plu sin inregistration. On posse celar e "
 "ordinar ludes o descargar covrimentes de SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detallies del lude"
 
@@ -61,8 +61,8 @@ msgid "Edit Game Details"
 msgstr "Redacter li detallies del lude"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferenties"
 
@@ -70,47 +70,47 @@ msgstr "Preferenties"
 msgid "Cancel"
 msgstr "Anullar"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nov covriment"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Remover li covriment"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titul"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Developator (facultativ)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Executibile"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Selecter un file"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Plu information"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Redacter"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Celar"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Remover"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Revelar"
 
@@ -118,17 +118,17 @@ msgstr "Revelar"
 msgid "General"
 msgstr "General"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Serchar"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Rapid-tastes"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Defar"
 
@@ -136,11 +136,11 @@ msgstr "Defar"
 msgid "Quit"
 msgstr "Surtir"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Panel lateral"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menú principal"
 
@@ -148,12 +148,12 @@ msgstr "Menú principal"
 msgid "Games"
 msgstr "Ludes"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Adjunter un lude"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importar"
 
@@ -165,8 +165,8 @@ msgstr "Monstrar celat ludes"
 msgid "Remove Game"
 msgstr "Remover li lude"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Conduida"
 
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Images"
 
@@ -198,137 +198,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Remover omni ludes"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Remover desinstallat ludes"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Orígines"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Localisation de installation"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importar ludes de Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importar ludes Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importar ludes de Epic"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importar ludes de GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importar ludes de Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Botelles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Localisation del sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Localisation del usator"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importar lansatores de ludes"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Files desktop"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autentication"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Clave de API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Descargar images quande on adjunte o importa ludes"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Actualisar covrimentes"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Obtener covrimentes por ludes in vor biblioteca"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Actualisar"
 
@@ -356,135 +360,136 @@ msgstr "Null celat ludes"
 msgid "Games you hide will appear here"
 msgstr "Ludes celat de vos va aparir ci ti"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Omni ludes"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Adjuntet"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importat"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Celat ludes"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Titul del lude"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Luder"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordinar"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Plu recent"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Plu old"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Ludet"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Revelar celat"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Pri Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} ea lansat"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "OIS <mistresssilvara@hotmail.com>, 2024"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Adjuntet: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nequande"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Ludet: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Applicar"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Adjunter un nov lude"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Adjunter"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Executibiles"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programma"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\rute\\a\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/rute/a/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -506,19 +511,19 @@ msgstr ""
 "\n"
 "Si li rute contene spacies, metter it in signes de citation (\"\")!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Ne successat adjunter un lude"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Li titul ne posse esser vacui."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Li executibile es besonat."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Ne successat adjunter li preferenties"
 
@@ -532,50 +537,49 @@ msgid "{} unhidden"
 msgstr "{} revelat"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} sta removet"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Omni ludes sta removet"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Un clave de API es besonat por SteamGridDB. Vu posse generar ún {}ci ti{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Descarga de covrimentes…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Li covrimentes sta actualisat"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installation ne es trovat"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Ples selecter un valid categorie"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Avise"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Ínvalid fólder"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Assignar li localisation"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Demisser"
 
@@ -583,27 +587,29 @@ msgstr "Demisser"
 msgid "Importing Games…"
 msgstr "Importation de ludes…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Li sequent errorees evenit durante li importation:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Null nov ludes trovat"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 lude sta importat"
+msgid_plural "{} games imported"
+msgstr[0] "1 lude sta importat"
+msgstr[1] "{} ludes sta importat"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} ludes sta importat"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 removet"
+msgid_plural "{} removed"
+msgstr[0] "1 removet"
+msgstr[1] "{} removet"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -640,3 +646,6 @@ msgstr "Autentication ínvalid de SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Ples controlar vor clave de API in li preferenties"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} ludes sta importat"

--- a/po/it.po
+++ b/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-02-24 08:02+0000\n"
 "Last-Translator: Andrea Costola <lamaildiandreac@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/cartridges/"
@@ -542,9 +542,13 @@ msgid "{} unhidden"
 msgstr "{} visibile"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} rimosso"
+msgid_plural "{} removed"
+msgstr[0] "{} rimosso"
+msgstr[1] "{} rimosso"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -589,6 +593,32 @@ msgstr "Imposta percorso"
 msgid "Dismiss"
 msgstr "Chiudi"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Oggi"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Ieri"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Ultimo Avvio"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Ultimo Avvio"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Import dei giochi in corso…"
@@ -604,18 +634,10 @@ msgstr "Nessun nuovo gioco trovato"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 gioco importato"
+msgstr[0] "{} giochi importati"
 msgstr[1] "{} giochi importati"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 rimosso"
-msgstr[1] "{} rimossi"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -653,8 +675,17 @@ msgstr "Impossibile autenticare SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifica la tua chiave API nelle preferenze"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} giochi importati"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 gioco importato"
+#~ msgstr[1] "{} giochi importati"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 rimosso"
+#~ msgstr[1] "{} rimossi"
 
 #~ msgid "Cache Location"
 #~ msgstr "Posizione della cache"
@@ -717,12 +748,6 @@ msgstr "Verifica la tua chiave API nelle preferenze"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Percorso Installazione Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Oggi"
-
-#~ msgid "Yesterday"
-#~ msgstr "Ieri"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Cache non trovata"

--- a/po/it.po
+++ b/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-02-24 08:02+0000\n"
 "Last-Translator: Andrea Costola <lamaildiandreac@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/cartridges/"
@@ -439,9 +439,8 @@ msgstr ""
 msgid "{} launched"
 msgstr "{} avviato"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Alessandro Iepure https://ale.iepure.me"
 

--- a/po/it.po
+++ b/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-02-24 08:02+0000\n"
 "Last-Translator: Andrea Costola <lamaildiandreac@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/cartridges/"
@@ -56,8 +56,8 @@ msgstr ""
 "organizzare e nascondere i giochi oppure scaricare le copertine da "
 "StreamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Dettagli del gioco"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Modifica dettagli del gioco"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferenze"
 
@@ -75,47 +75,47 @@ msgstr "Preferenze"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nuova copertina"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Elimina copertina"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titolo"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Sviluppatore (opzionale)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Eseguibile"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Seleziona file"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Altre informazioni"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Modifica"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Nascondi"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Mostra"
 
@@ -123,17 +123,17 @@ msgstr "Mostra"
 msgid "General"
 msgstr "Generale"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Cerca"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie da Tastiera"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Annulla"
 
@@ -141,11 +141,11 @@ msgstr "Annulla"
 msgid "Quit"
 msgstr "Esci"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Attiva/disattiva la barra laterale"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menù Principale"
 
@@ -153,12 +153,12 @@ msgstr "Menù Principale"
 msgid "Games"
 msgstr "Giochi"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Aggiungi Gioco"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importa"
 
@@ -170,8 +170,8 @@ msgstr "Mostra Giochi nascosti"
 msgid "Remove Game"
 msgstr "Rimuovi Gioco"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -187,7 +187,7 @@ msgstr "La copertina avvia il gioco"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Inverti il comportamento della copertina con il pulsante di avvio"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Immagini"
 
@@ -204,137 +204,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Zona di pericolo"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Rimuovi tutti i giochi"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Rimuovi giochi disinstallati"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Fonti"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Posizione di installazione"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importa giochi da Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importa giochi da Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importa giochi da Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importa giochi da GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importa giochi Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importa giochi da aggiunti manualmente"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Percorso di sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Percorso utente"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importa launcher di giochi"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Elementi Desktop"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autenticazione"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Chiave API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Usa SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Scarica immagini durante l'aggiunta o l'import di giochi"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferisci alle immagini ufficiali"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Preferisci immagini animate"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Aggiorna copertina"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Recupera le copertine dei giochi già presenti nella tua libreria"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Aggiorna"
 
@@ -362,135 +366,136 @@ msgstr "Nessun Gioco Nascosto"
 msgid "Games you hide will appear here"
 msgstr "I giochi nascosti appariranno qui"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Tutti i giochi"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Aggiunto"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importato"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Giochi Nascosti"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Titolo del gioco"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Gioca"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordina per"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Più recente"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Più vecchio"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Ultimo Avvio"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Mostra Nascosti"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Informazioni su Cartucce"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} avviato"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Alessandro Iepure https://ale.iepure.me"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Aggiunto il: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Mai"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Ultima riproduzione: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Applica"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Aggiungi un Nuovo Gioco"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Aggiungi"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Eseguibili"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programma"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\path\\to{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/percorso/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "\n"
 "Se il percorso contiene spazi, assicurarsi di avvolgerlo in doppi apici!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Impossibile aggiungere il gioco"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Il titolo del gioco non può essere vuoto."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "L'eseguibile non può essere vuoto."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Impossibile applicare le preferenze"
 
@@ -538,51 +543,50 @@ msgid "{} unhidden"
 msgstr "{} visibile"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} rimosso"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Tutti i giochi sono stati rimossi"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Per utilizzare SteamGridDB è necessaria una chiave API. Puoi generarne una {}"
 "qui{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Download delle copertine…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Copertine aggiornate"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installazione non trovata"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Seleziona una directory valida"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Attenzione"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Directory non valida"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Imposta percorso"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Chiudi"
 
@@ -590,27 +594,29 @@ msgstr "Chiudi"
 msgid "Importing Games…"
 msgstr "Import dei giochi in corso…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Durante l'importazione si sono verificati i seguenti errori:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nessun nuovo gioco trovato"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 gioco importato"
+msgid_plural "{} games imported"
+msgstr[0] "1 gioco importato"
+msgstr[1] "{} giochi importati"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} giochi importati"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 rimosso"
+msgid_plural "{} removed"
+msgstr[0] "1 rimosso"
+msgstr[1] "{} rimossi"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -647,6 +653,9 @@ msgstr "Impossibile autenticare SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifica la tua chiave API nelle preferenze"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} giochi importati"
 
 #~ msgid "Cache Location"
 #~ msgstr "Posizione della cache"

--- a/po/it.po
+++ b/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-02-24 08:02+0000\n"
 "Last-Translator: Andrea Costola <lamaildiandreac@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/cartridges/"
@@ -67,7 +67,7 @@ msgstr "Modifica dettagli del gioco"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferenze"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie da Tastiera"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Annulla"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Rimuovi Gioco"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -208,137 +208,137 @@ msgstr "Zona di pericolo"
 msgid "Remove All Games"
 msgstr "Rimuovi tutti i giochi"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Rimuovi giochi disinstallati"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Fonti"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Posizione di installazione"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importa giochi da Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importa giochi da Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importa giochi da Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importa giochi da GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importa giochi Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importa giochi da aggiunti manualmente"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Percorso di sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Percorso utente"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importa launcher di giochi"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Elementi Desktop"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autenticazione"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Chiave API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Usa SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Scarica immagini durante l'aggiunta o l'import di giochi"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferisci alle immagini ufficiali"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferisci immagini animate"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Aggiorna copertina"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Recupera le copertine dei giochi già presenti nella tua libreria"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Aggiorna"
 
@@ -546,46 +546,46 @@ msgstr "{} visibile"
 msgid "{} removed"
 msgstr "{} rimosso"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Tutti i giochi sono stati rimossi"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Per utilizzare SteamGridDB è necessaria una chiave API. Puoi generarne una {}"
 "qui{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Download delle copertine…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Copertine aggiornate"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installazione non trovata"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Seleziona una directory valida"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Attenzione"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Directory non valida"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Imposta percorso"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Chiudi"
 
@@ -593,16 +593,16 @@ msgstr "Chiudi"
 msgid "Importing Games…"
 msgstr "Import dei giochi in corso…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Durante l'importazione si sono verificati i seguenti errori:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nessun nuovo gioco trovato"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[0] "1 gioco importato"
 msgstr[1] "{} giochi importati"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/cartridges/"
@@ -523,9 +523,11 @@ msgid "{} unhidden"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
 msgid "{} removed"
-msgstr ""
+msgid_plural "{} removed"
+msgstr[0] ""
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -568,6 +570,30 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+msgid "Last Week"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+msgid "Last Year"
+msgstr ""
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr ""
@@ -582,14 +608,8 @@ msgstr ""
 
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] ""
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-msgid "1 removed"
-msgid_plural "{} removed"
 msgstr[0] ""
 
 #. The variable is the name of the source

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/cartridges/"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr ""
 
@@ -124,7 +124,7 @@ msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr ""
 
@@ -162,7 +162,7 @@ msgid "Remove Game"
 msgstr ""
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr ""
 
@@ -198,137 +198,137 @@ msgstr ""
 msgid "Remove All Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr ""
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr ""
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr ""
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr ""
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr ""
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr ""
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr ""
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr ""
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr ""
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr ""
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr ""
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr ""
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr ""
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr ""
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr ""
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr ""
 
@@ -527,44 +527,44 @@ msgstr ""
 msgid "{} removed"
 msgstr ""
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr ""
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr ""
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr ""
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr ""
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "警告"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr ""
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr ""
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr ""
 
@@ -572,22 +572,22 @@ msgstr ""
 msgid "Importing Games…"
 msgstr ""
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr ""
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] ""
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 msgid "1 removed"
 msgid_plural "{} removed"
 msgstr[0] ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/cartridges/"
@@ -47,8 +47,8 @@ msgid ""
 "SteamGridDB."
 msgstr ""
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr ""
 
@@ -57,8 +57,8 @@ msgid "Edit Game Details"
 msgstr ""
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr ""
 
@@ -66,47 +66,47 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr ""
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr ""
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr ""
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr ""
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr ""
 
@@ -114,17 +114,17 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr ""
 
@@ -132,11 +132,11 @@ msgstr ""
 msgid "Quit"
 msgstr "終了"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr ""
 
@@ -144,12 +144,12 @@ msgstr ""
 msgid "Games"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr ""
 
@@ -161,8 +161,8 @@ msgstr ""
 msgid "Remove Game"
 msgstr ""
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr ""
 
@@ -194,137 +194,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr ""
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr ""
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr ""
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr ""
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr ""
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr ""
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr ""
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr ""
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr ""
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr ""
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr ""
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr ""
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr ""
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr ""
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr ""
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr ""
 
@@ -352,135 +356,135 @@ msgstr ""
 msgid "Games you hide will appear here"
 msgstr ""
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr ""
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr ""
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr ""
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr ""
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr ""
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr ""
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr ""
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr ""
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr ""
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr ""
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr ""
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr ""
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr ""
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr ""
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr ""
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+msgid "translator-credits"
 msgstr ""
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr ""
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr ""
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr ""
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "適用"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr ""
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr ""
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "ファイル.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr ""
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -493,19 +497,19 @@ msgid ""
 "If the path contains spaces, make sure to wrap it in double quotes!"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr ""
 
@@ -519,49 +523,48 @@ msgid "{} unhidden"
 msgstr ""
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr ""
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr ""
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr ""
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr ""
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr ""
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "警告"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr ""
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr ""
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr ""
 
@@ -569,27 +572,25 @@ msgstr ""
 msgid "Importing Games…"
 msgstr ""
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr ""
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
 msgid "1 game imported"
-msgstr ""
+msgid_plural "{} games imported"
+msgstr[0] ""
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr ""
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
 msgid "1 removed"
-msgstr ""
+msgid_plural "{} removed"
+msgstr[0] ""
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-01-16 06:06+0000\n"
 "Last-Translator: Scott Anecito <scott.anecito@linux.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/cartridges/"
@@ -429,7 +429,7 @@ msgstr ""
 msgid "{} launched"
 msgstr ""
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 msgid "translator-credits"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-03-02 19:01+0000\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/cartridges/"
@@ -436,9 +436,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} 실행함"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "조성호 <shcho@gnome.org>"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-03-02 19:01+0000\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "게임 세부 정보 편집"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "기본 설정"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "키보드 바로 가기 키"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "실행 취소"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "게임 제거"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "동작"
 
@@ -205,137 +205,137 @@ msgstr "위험 영역"
 msgid "Remove All Games"
 msgstr "모든 게임 제거"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "설치 취소한 게임 제거"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "공급원"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "스팀"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "설치 위치"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "루트리스"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "스팀 게임 가져오기"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "플랫팩 게임 가져오기"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "히어로익"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "에픽 게임 가져오기"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG 게임 가져오기"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "아마존 게임 가져오기"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "사이드로디드 게임 가져오기"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "보틀즈"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "잇치"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "레젠더리"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "레트로아키"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "플랫팩"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "시스템 위치"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "사용자 위치"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "게임 실행 프로그램 가져오기"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "데스크톱 항목"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "인증"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API 키"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB 활용"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "게임을 추가하거나 가져올 때 표지 그림 다운로드"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "공식 그림 우선"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "움직이는 그림 우선"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "표지 그림 업데이트"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "라이브러리에 이미 있는 게임 표지 그림 가져오기"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "업데이트"
 
@@ -544,45 +544,45 @@ msgstr "{} 숨김 해제함"
 msgid "{} removed"
 msgstr "{} 제거함"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "모든 게임을 제거했습니다"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB를 활용하려면 API 키가 필요합니다. {}여기{}에서 만들 수 있습니다."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "표지 그림 다운로드 중…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "표지 그림을 업데이트했습니다"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "설치한 항목이 없습니다"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "올바른 디렉터리를 선택하십시오"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "경고"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "부적절한 디렉터리"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "위치 설정"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "버리기"
 
@@ -590,23 +590,23 @@ msgstr "버리기"
 msgid "Importing Games…"
 msgstr "게임 가져오는 중…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "가져오는 동안 다음 오류가 나타났습니다:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "새 게임이 없습니다"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] "게임 {}건을 가져왔습니다"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-03-02 19:01+0000\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/cartridges/"
@@ -540,9 +540,12 @@ msgid "{} unhidden"
 msgstr "{} 숨김 해제함"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} 제거함"
+msgid_plural "{} removed"
+msgstr[0] "{} 제거함"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -586,6 +589,32 @@ msgstr "위치 설정"
 msgid "Dismiss"
 msgstr "버리기"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "최근 플레이"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "최근 플레이"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "게임 가져오는 중…"
@@ -601,16 +630,9 @@ msgstr "새 게임이 없습니다"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
 msgstr[0] "게임 {}건을 가져왔습니다"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "{}건을 제거했습니다"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -648,8 +670,15 @@ msgstr "SteamGridDB를 인증할 수 없습니다"
 msgid "Verify your API key in preferences"
 msgstr "기본 설정에서 API 키를 검증하십시오"
 
-#~ msgid "{} games imported"
-#~ msgstr "게임 {}건을 가져왔습니다"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "게임 {}건을 가져왔습니다"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "{}건을 제거했습니다"
 
 #~ msgid "Cache Location"
 #~ msgstr "캐시 위치"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-03-02 19:01+0000\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "이트에서 로그인을 하지 않고 게임을 가져올 수 있습니다. 게임을 정리하고 숨기거"
 "나, SteamGridDB에서 표지를 다운로드할 수 있습니다."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "게임 세부 정보"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "게임 세부 정보 편집"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "기본 설정"
 
@@ -73,47 +73,47 @@ msgstr "기본 설정"
 msgid "Cancel"
 msgstr "취소"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "새 표지"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "표지 삭제"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "제목"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "개발자 (옵션)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "실행 가능"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "파일 선택"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "추가 정보"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "편집"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "숨기기"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "제거"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "숨기기 취소"
 
@@ -121,17 +121,17 @@ msgstr "숨기기 취소"
 msgid "General"
 msgstr "일반"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "검색"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "키보드 바로 가기 키"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "실행 취소"
 
@@ -139,11 +139,11 @@ msgstr "실행 취소"
 msgid "Quit"
 msgstr "끝내기"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "가장 자리 창 표시 전환"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "메인 메뉴"
 
@@ -151,12 +151,12 @@ msgstr "메인 메뉴"
 msgid "Games"
 msgstr "게임"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "게임 추가"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "가져오기"
 
@@ -168,8 +168,8 @@ msgstr "숨긴 게임 표시"
 msgid "Remove Game"
 msgstr "게임 제거"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "동작"
 
@@ -185,7 +185,7 @@ msgstr "표지 그림 선택시 게임 실행"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "표지 그림과 게임하기 단추 동작 바꾸기"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "그림"
 
@@ -201,137 +201,141 @@ msgstr "게임 표지를 화질 손실 없도록 저장소를 충분히 할애�
 msgid "Danger Zone"
 msgstr "위험 영역"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "모든 게임 제거"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "설치 취소한 게임 제거"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "공급원"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "스팀"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "설치 위치"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "루트리스"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "스팀 게임 가져오기"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "플랫팩 게임 가져오기"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "히어로익"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "에픽 게임 가져오기"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG 게임 가져오기"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "아마존 게임 가져오기"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "사이드로디드 게임 가져오기"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "보틀즈"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "잇치"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "레젠더리"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "레트로아키"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "플랫팩"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "시스템 위치"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "사용자 위치"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "게임 실행 프로그램 가져오기"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "데스크톱 항목"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "인증"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API 키"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB 활용"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "게임을 추가하거나 가져올 때 표지 그림 다운로드"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "공식 그림 우선"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "움직이는 그림 우선"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "표지 그림 업데이트"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "라이브러리에 이미 있는 게임 표지 그림 가져오기"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "업데이트"
 
@@ -359,135 +363,136 @@ msgstr "숨긴 게임 없음"
 msgid "Games you hide will appear here"
 msgstr "숨긴 게임이 이곳에 나타납니다"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "모든 게임"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "추가함"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "가져옴"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "숨긴 게임"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "게임 제목"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "게임하기"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "정렬"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "오름차순"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "내림차순"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "최신순"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "과거순"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "최근 플레이"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "숨긴 게임 표시"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "카트리지 정보"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} 실행함"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "조성호 <shcho@gnome.org>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "추가: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "안함"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "최근 플레이: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "적용"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "새 게임 추가"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "추가"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "실행 파일"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "프로그램"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\디렉터리\\경로\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/디렉터리/경로/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -510,19 +515,19 @@ msgstr ""
 "경로 이름에 공백 문자가 들어가 있을 경우, 경로 이름을 큰 따옴표로 감쌌는지 확"
 "인하십시오!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "게임을 추가할 수 없습니다"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "게임 제목은 비워둘 수 없습니다."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "실행 파일을 비워둘 수 없습니다."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "기본 설정을 적용할 수 없습니다"
 
@@ -536,50 +541,49 @@ msgid "{} unhidden"
 msgstr "{} 숨김 해제함"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} 제거함"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "모든 게임을 제거했습니다"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDB를 활용하려면 API 키가 필요합니다. {}여기{}에서 만들 수 있습니다."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "표지 그림 다운로드 중…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "표지 그림을 업데이트했습니다"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "설치한 항목이 없습니다"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "올바른 디렉터리를 선택하십시오"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "경고"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "부적절한 디렉터리"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "위치 설정"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "버리기"
 
@@ -587,27 +591,27 @@ msgstr "버리기"
 msgid "Importing Games…"
 msgstr "게임 가져오는 중…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "가져오는 동안 다음 오류가 나타났습니다:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "새 게임이 없습니다"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "게임 1건을 가져왔습니다"
+msgid_plural "{} games imported"
+msgstr[0] "게임 {}건을 가져왔습니다"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "게임 {}건을 가져왔습니다"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1건을 제거했습니다"
+msgid_plural "{} removed"
+msgstr[0] "{}건을 제거했습니다"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -644,6 +648,9 @@ msgstr "SteamGridDB를 인증할 수 없습니다"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "기본 설정에서 API 키를 검증하십시오"
+
+#~ msgid "{} games imported"
+#~ msgstr "게임 {}건을 가져왔습니다"
 
 #~ msgid "Cache Location"
 #~ msgstr "캐시 위치"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-10-22 13:02+0200\n"
 "Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -418,7 +418,7 @@ msgstr "Vis skjulte"
 
 #: data/gtk/window.blp:545
 msgid "About Cartridges"
-msgstr "Om"
+msgstr "Om Cartridges"
 
 #: data/gtk/window.blp:562
 msgid "IGDB"
@@ -437,7 +437,7 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} startet"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 msgid "translator-credits"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
-"PO-Revision-Date: 2024-10-22 13:02+0200\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
+"PO-Revision-Date: 2024-11-02 23:02+0100\n"
 "Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
 "cartridges/cartridges/nb_NO/>\n"
@@ -208,7 +208,7 @@ msgstr "Fjern alle spill"
 
 #: data/gtk/preferences.blp:65
 msgid "Import Games Automatically"
-msgstr ""
+msgstr "Importer spill automatisk"
 
 #: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
@@ -543,9 +543,12 @@ msgid "{} unhidden"
 msgstr "{} synlig"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
 msgid "{} removed"
-msgstr "{} fjernet"
+msgid_plural "{} removed"
+msgstr[0] "{} fjernet"
+msgstr[1] "{} fjernet"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -589,6 +592,30 @@ msgstr "Angi lagringssted"
 msgid "Dismiss"
 msgstr "Forkast"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "I dag"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "I går"
+
+#: cartridges/utils/relative_date.py:36
+msgid "Last Week"
+msgstr "Forrige uke"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr "Denne måneden"
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr "Forrige måned"
+
+#: cartridges/utils/relative_date.py:44
+msgid "Last Year"
+msgstr "I fjor"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importerer spill …"
@@ -603,17 +630,10 @@ msgstr "Fant ingen nye spill"
 
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "Ett spill importert"
+msgstr[0] "{} spill importert"
 msgstr[1] "{} spill importert"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "Ett spill fjernet"
-msgstr[1] "{} spill fjernet"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -651,11 +671,18 @@ msgstr "Kunne ikke autentisere SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifiser API-nøkkelen din i Brukervalg"
 
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "{} spill importert"
+#~ msgstr[1] "{} spill importert"
+
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "{} spill fjernet"
+#~ msgstr[1] "{} spill fjernet"
+
 #~ msgid "Reset App"
 #~ msgstr "Tilbakestill"
-
-#~ msgid "{} games imported"
-#~ msgstr "{} spill importert"
 
 #, fuzzy
 #~ msgid "Cache Location"
@@ -722,12 +749,6 @@ msgstr "Verifiser API-nøkkelen din i Brukervalg"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Installasjonssted for Bottles"
-
-#~ msgid "Today"
-#~ msgstr "I dag"
-
-#~ msgid "Yesterday"
-#~ msgstr "I går"
 
 #, fuzzy
 #~ msgid "Cache Not Found"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -3,13 +3,14 @@
 # This file is distributed under the same license as the cartridges package.
 # kramo <contact@kramo.hu>, 2023.
 # Allan Nordhøy <epost@anotheragency.no>, 2023.
+# sunniva <weblate@turtle.garden>, 2024.
 msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
-"PO-Revision-Date: 2023-04-06 08:09+0000\n"
-"Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"PO-Revision-Date: 2024-10-22 13:02+0200\n"
+"Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
 "cartridges/cartridges/nb_NO/>\n"
 "Language: nb_NO\n"
@@ -17,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17-dev\n"
+"X-Generator: Poedit 3.5\n"
 
 #: data/page.kramo.Cartridges.desktop.in:3
 #: data/page.kramo.Cartridges.metainfo.xml.in:9
@@ -39,6 +40,8 @@ msgstr "Start alle spillene dine"
 msgid ""
 "gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;legendary;retroarch;"
 msgstr ""
+"gaming;lansere;spillstartere;steam;lutris;heroic;bottles;flasker;flatpak;"
+"legendary;retroarch;"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:12
 msgid ""
@@ -52,8 +55,8 @@ msgstr ""
 "innlogging. Du kan sortere og skjule spil eller laste ned omslagsbilder fra "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Spilldetaljer"
 
@@ -62,76 +65,74 @@ msgid "Edit Game Details"
 msgstr "Rediger spilldetaljer"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
-msgstr "Innstillinger"
+msgstr "Brukervalg"
 
 #: data/gtk/details-dialog.blp:15
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
-msgstr ""
+msgstr "Nytt omslag"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
-msgstr ""
+msgstr "Fjern omslag"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Navn"
 
-#: data/gtk/details-dialog.blp:97
-#, fuzzy
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
-msgstr "Utvikler eller utgiver (valgfritt)"
+msgstr "Utvikler (valgfritt)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Kjørbar"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
-msgstr ""
+msgstr "Velg fil"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
-msgstr ""
+msgstr "Mer informasjon"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Rediger"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Skjul"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Fjern"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
-msgstr "Opphev fjerning"
+msgstr "Vis"
 
 #: data/gtk/help-overlay.blp:11 data/gtk/preferences.blp:9
 msgid "General"
 msgstr "Generelt"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
-#, fuzzy
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Søk"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Tastatursnarveier"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Angre"
 
@@ -139,11 +140,11 @@ msgstr "Angre"
 msgid "Quit"
 msgstr "Avslutt"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
-msgstr ""
+msgstr "Vis/skjul sidefelt"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Hovedmeny"
 
@@ -151,30 +152,27 @@ msgstr "Hovedmeny"
 msgid "Games"
 msgstr "Spill"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Legg til spill"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importer"
 
 #: data/gtk/help-overlay.blp:63
-#, fuzzy
 msgid "Show Hidden Games"
 msgstr "Vis skjulte spill"
 
 #: data/gtk/help-overlay.blp:68
-#, fuzzy
 msgid "Remove Game"
 msgstr "Fjern spill"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
-#, fuzzy
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
-msgstr "Adferd"
+msgstr "Atferd"
 
 #: data/gtk/preferences.blp:16
 msgid "Exit After Launching Games"
@@ -188,7 +186,7 @@ msgstr "Omslagsbilde starter spill"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Bytter adferd for omslagsbilde og spill-knapp"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Bilder"
 
@@ -204,151 +202,143 @@ msgstr "Lagre spillomslag tapsfritt på bekostning av lagringsplass"
 msgid "Danger Zone"
 msgstr "Faresone"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Fjern alle spill"
 
-#: data/gtk/preferences.blp:120
-#, fuzzy
-msgid "Remove Uninstalled Games"
-msgstr "Fjern alle spill"
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr "Tilbakestill"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:65
+msgid "Remove Uninstalled Games"
+msgstr "Fjern avinstallerte spill"
+
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Kilder"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
-#, fuzzy
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
-msgstr "Installasjonssted for itch"
+msgstr "Installasjonssted"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
-#, fuzzy
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
-msgstr "Importer sideinnlastede spill"
+msgstr "Import Steam-spill"
 
-#: data/gtk/preferences.blp:185
-#, fuzzy
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
-msgstr "Importer sideinnlastede spill"
+msgstr "Importer Flatpak-spill"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importer Epic-spill"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importer GOG-spill"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importer Amazon-spill"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importer sideinnlastede spill"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
-#, fuzzy
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
-msgstr ""
+msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
-msgstr ""
+msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
-msgstr ""
+msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
-#, fuzzy
+#: data/gtk/preferences.blp:297
 msgid "System Location"
-msgstr "Velg mappe"
+msgstr "System-lagringssted"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
-#, fuzzy
+#: data/gtk/preferences.blp:315
 msgid "User Location"
-msgstr "Velg mappe"
+msgstr "Bruker-lagringssted"
 
-#: data/gtk/preferences.blp:386
-#, fuzzy
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
-msgstr "Spillutvalgstarter"
+msgstr "Importer spillstartere"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
-msgstr ""
+msgstr "Skrivebordsoppføringer"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Identitetsbekreftelse"
 
-#: data/gtk/preferences.blp:410
-#, fuzzy
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-nøkkel"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Bruk SteamGridDB"
 
-#: data/gtk/preferences.blp:419
-#, fuzzy
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
-msgstr "Mappe å bruke ved import av spill"
+msgstr "Last ned bilder når spill legges til eller importeres"
 
-#: data/gtk/preferences.blp:423
-#, fuzzy
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
-msgstr "Foretrekk over offisielle bilder"
+msgstr "Foretrekk fremfor offisielle bilder"
 
-#: data/gtk/preferences.blp:427
-#, fuzzy
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
-msgstr "Foretrekk over offisielle bilder"
+msgstr "Foretrekk animerte bilder"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
-msgstr ""
+msgstr "Oppdater omslag"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
-msgstr ""
+msgstr "Hente omslag til spill som allerede finnes i biblioteket ditt"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
-msgstr ""
+msgstr "Oppdater"
 
 #: data/gtk/window.blp:6 data/gtk/window.blp:14
 msgid "No Games Found"
@@ -374,139 +364,137 @@ msgstr "Ingen skjulte spill"
 msgid "Games you hide will appear here"
 msgstr "Spill du skjuler vil vises her"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
-#, fuzzy
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
-msgstr "Fjern alle spill"
+msgstr "Alle spill"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
-#, fuzzy
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
-msgstr "Tillagt: {}"
+msgstr "Tillagte"
 
-#: data/gtk/window.blp:156
-#, fuzzy
+#: data/gtk/window.blp:162
 msgid "Imported"
-msgstr "Importer"
+msgstr "Importerte"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Skjulte spill"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Spillnavn"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Spill"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sorter"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Å"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Å-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Nyeste"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Eldste"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Sist spilt"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Vis skjulte"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Om"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
-msgstr ""
+msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
-msgstr ""
+msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
-msgstr ""
+msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} startet"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
-msgstr "Allan Nordhøy, <epost@anotheragency.no>"
+#: cartridges/main.py:291
+msgid "translator-credits"
+msgstr ""
+"Allan Nordhøy <epost@anotheragency.no>\n"
+"Sunniva Løvstad <cartridges@turtle.garden>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Tillagt: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Aldri"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Sist spilt: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Bruk"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Legg til nytt spill"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
-msgstr ""
+msgstr "Legg til"
 
-#: cartridges/details_dialog.py:90
-#, fuzzy
+#: cartridges/details_dialog.py:99
 msgid "Executables"
-msgstr "Kjørbar"
+msgstr "Kjørbare filer"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "fil.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\sti\\til\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/sti/til/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -526,28 +514,27 @@ msgstr ""
 "\n"
 "<tt>{} «{}»</tt>\n"
 "\n"
-"Hvis stien inneholder mellomrom må du pakke den inn i doble engelske "
+"Hvis stien inneholder mellomrom, må du pakke den inn i doble engelske "
 "sitattegn."
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Kunne ikke legge til spill"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Spillnavnet kan ikke være tomt."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Kjørbar fil må angis."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Kunne ikke ta i bruk endringer"
 
 #. The variable is the title of the game
 #: cartridges/game.py:139
-#, fuzzy
 msgid "{} hidden"
 msgstr "{} skjult"
 
@@ -556,54 +543,49 @@ msgid "{} unhidden"
 msgstr "{} synlig"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} fjernet"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Alle spill fjernet"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "En API-nøkkel kreves for å bruke SteamGridDB. Du kan generere en {}her{}."
 
-#: cartridges/preferences.py:196
-#, fuzzy
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
-msgstr "Importerer omslag …"
+msgstr "Laster ned omslag…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
-msgstr ""
+msgstr "Omslag oppdaterte"
 
-#: cartridges/preferences.py:360
-#, fuzzy
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
-msgstr "Fant ikke installasjonen"
+msgstr "Fant ikke installasjon"
 
-#: cartridges/preferences.py:361
-#, fuzzy
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
-msgstr "Velg {}-datamappen."
+msgstr "Velg en gyldig datamappe"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
-msgstr ""
+msgstr "Advarsel"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
-msgstr ""
+msgstr "Ugyldig filmappe"
 
-#: cartridges/preferences.py:437
-#, fuzzy
+#: cartridges/preferences.py:445
 msgid "Set Location"
-msgstr "Velg mappe"
+msgstr "Angi lagringssted"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Forkast"
 
@@ -611,71 +593,66 @@ msgstr "Forkast"
 msgid "Importing Games…"
 msgstr "Importerer spill …"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
-msgstr ""
+msgstr "De følgende feilene oppsto under importering:"
 
-#: cartridges/importer/importer.py:367
-#, fuzzy
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
-msgstr "Fant ingen spill"
+msgstr "Fant ingen nye spill"
 
-#: cartridges/importer/importer.py:379
-#, fuzzy
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
 msgid "1 game imported"
-msgstr "Spill importert"
+msgid_plural "{} games imported"
+msgstr[0] "Ett spill importert"
+msgstr[1] "{} spill importert"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-#, fuzzy
-msgid "{} games imported"
-msgstr "Spill importert"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
-#, fuzzy
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
 msgid "1 removed"
-msgstr "{} fjernet"
+msgid_plural "{} removed"
+msgstr[0] "Ett spill fjernet"
+msgstr[1] "{} spill fjernet"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
-#, fuzzy
 msgid "Select the {} cache directory."
-msgstr "Velg {}-datamappen."
+msgstr "Velg {}-hurtiglagermappen."
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:36
-#, fuzzy
 msgid "Select the {} configuration directory."
 msgstr "Velg {}-oppsettsmappen."
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:38
-#, fuzzy
 msgid "Select the {} data directory."
 msgstr "Velg {}-datamappen."
 
 #: cartridges/importer/retroarch_source.py:129
 msgid "No RetroArch Core Selected"
-msgstr ""
+msgstr "Ingen RetroArch-kjerne valgt"
 
 #. The variable is a newline separated list of playlists
 #: cartridges/importer/retroarch_source.py:131
 msgid "The following playlists have no default core:"
-msgstr ""
+msgstr "De følgende spillelister har ingen standardkjerne:"
 
 #: cartridges/importer/retroarch_source.py:133
 msgid "Games with no core selected were not imported"
-msgstr ""
+msgstr "Spill med ingen kjerne valgt har ikke blitt importert"
 
 #: cartridges/store/managers/sgdb_manager.py:46
-#, fuzzy
 msgid "Couldn't Authenticate SteamGridDB"
-msgstr "Kunne ikke koble til SteamGridDB"
+msgstr "Kunne ikke autentisere SteamGridDB"
 
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
-msgstr ""
+msgstr "Verifiser API-nøkkelen din i Brukervalg"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} spill importert"
 
 #, fuzzy
 #~ msgid "Cache Location"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-10-22 13:02+0200\n"
 "Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -66,7 +66,7 @@ msgstr "Rediger spilldetaljer"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Brukervalg"
 
@@ -132,7 +132,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Tastatursnarveier"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Angre"
 
@@ -170,7 +170,7 @@ msgid "Remove Game"
 msgstr "Fjern spill"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Atferd"
 
@@ -206,137 +206,137 @@ msgstr "Faresone"
 msgid "Remove All Games"
 msgstr "Fjern alle spill"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
-msgstr "Tilbakestill"
-
 #: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
+msgstr ""
+
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Fjern avinstallerte spill"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Kilder"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Installasjonssted"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Import Steam-spill"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importer Flatpak-spill"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importer Epic-spill"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importer GOG-spill"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importer Amazon-spill"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importer sideinnlastede spill"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "System-lagringssted"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Bruker-lagringssted"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importer spillstartere"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Skrivebordsoppføringer"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Identitetsbekreftelse"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-nøkkel"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Bruk SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Last ned bilder når spill legges til eller importeres"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Foretrekk fremfor offisielle bilder"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Foretrekk animerte bilder"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Oppdater omslag"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Hente omslag til spill som allerede finnes i biblioteket ditt"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Oppdater"
 
@@ -547,45 +547,45 @@ msgstr "{} synlig"
 msgid "{} removed"
 msgstr "{} fjernet"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Alle spill fjernet"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "En API-nøkkel kreves for å bruke SteamGridDB. Du kan generere en {}her{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Laster ned omslag…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Omslag oppdaterte"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Fant ikke installasjon"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Velg en gyldig datamappe"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Advarsel"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Ugyldig filmappe"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Angi lagringssted"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Forkast"
 
@@ -593,23 +593,23 @@ msgstr "Forkast"
 msgid "Importing Games…"
 msgstr "Importerer spill …"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "De følgende feilene oppsto under importering:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Fant ingen nye spill"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] "Ett spill importert"
 msgstr[1] "{} spill importert"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 msgid "1 removed"
 msgid_plural "{} removed"
 msgstr[0] "Ett spill fjernet"
@@ -650,6 +650,9 @@ msgstr "Kunne ikke autentisere SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifiser API-nøkkelen din i Brukervalg"
+
+#~ msgid "Reset App"
+#~ msgstr "Tilbakestill"
 
 #~ msgid "{} games imported"
 #~ msgstr "{} spill importert"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-02-15 17:02+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/cartridges/"
@@ -65,7 +65,7 @@ msgstr "Game-details bewerken"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Voorkeuren"
 
@@ -131,7 +131,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Ongedaan maken"
 
@@ -169,7 +169,7 @@ msgid "Remove Game"
 msgstr "Game verwijderen"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Gedrag"
 
@@ -206,137 +206,137 @@ msgstr "Gevarenzone"
 msgid "Remove All Games"
 msgstr "Alle games verwijderen"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Gedeïnstalleerde games verwijderen"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Bronnen"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Installatielocatie"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam-games importeren"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak-games importeren"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic-games importeren"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG-games importeren"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon-games importeren"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Gesideloade games importeren"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Systeem­locatie"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Gebruikers­locatie"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Game-launchers importeren"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Lokale apps"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Authenticatie"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-sleutel"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB gebruiken"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Afbeeldingen downloaden bij het toevoegen of importeren van games"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Voorkeur geven boven officiële afbeeldingen"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Voorkeur geven aan geanimeerde afbeeldingen"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Covers bijwerken"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Haal covers op voor games in uw bibliotheek"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Bijwerken"
 
@@ -546,46 +546,46 @@ msgstr "{} hersteld"
 msgid "{} removed"
 msgstr "{} verwijderd"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Alle games verwijderd"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Een API-sleutel is vereist om SteamGridDB te gebruiken. U kunt er {}hier{} "
 "één genereren."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Covers downloaden…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Covers bijgewerkt"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installatie niet gevonden"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Selecteer een geldige map"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Ongeldige map"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Locatie instellen"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Sluiten"
 
@@ -593,16 +593,16 @@ msgstr "Sluiten"
 msgid "Importing Games…"
 msgstr "Games importeren…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "De volgende fouten zijn opgetreden tijdens het importeren:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Geen nieuwe games gevonden"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[0] "1 game geïmporteerd"
 msgstr[1] "{} games geïmporteerd"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-02-15 17:02+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/cartridges/"
@@ -437,9 +437,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} gestart"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Philip Goto https://flipflop97.github.io/"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-02-15 17:02+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/cartridges/"
@@ -542,9 +542,13 @@ msgid "{} unhidden"
 msgstr "{} hersteld"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} verwijderd"
+msgid_plural "{} removed"
+msgstr[0] "{} verwijderd"
+msgstr[1] "{} verwijderd"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -589,6 +593,32 @@ msgstr "Locatie instellen"
 msgid "Dismiss"
 msgstr "Sluiten"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Vandaag"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Gisteren"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Laatst gespeeld"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Laatst gespeeld"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Games importeren…"
@@ -604,18 +634,10 @@ msgstr "Geen nieuwe games gevonden"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 game geïmporteerd"
+msgstr[0] "{} games geïmporteerd"
 msgstr[1] "{} games geïmporteerd"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 verwijderd"
-msgstr[1] "{} verwijderd"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -653,8 +675,17 @@ msgstr "Kan SteamGridDB niet authenticeren"
 msgid "Verify your API key in preferences"
 msgstr "Verifieer uw API-sleutel onder voorkeuren"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} games geïmporteerd"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 game geïmporteerd"
+#~ msgstr[1] "{} games geïmporteerd"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 verwijderd"
+#~ msgstr[1] "{} verwijderd"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache-locatie"
@@ -724,12 +755,6 @@ msgstr "Verifieer uw API-sleutel onder voorkeuren"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Installatielocatie van Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Vandaag"
-
-#~ msgid "Yesterday"
-#~ msgstr "Gisteren"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Cache niet gevonden"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-02-15 17:02+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/cartridges/"
@@ -54,8 +54,8 @@ msgstr ""
 "meer, zonder in te hoeven loggen. U kunt spellen sorteren, verbergen en "
 "covers van SteamGridDB downloaden."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Game-details"
 
@@ -64,8 +64,8 @@ msgid "Edit Game Details"
 msgstr "Game-details bewerken"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Voorkeuren"
 
@@ -73,47 +73,47 @@ msgstr "Voorkeuren"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nieuwe cover"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Cover verwijderen"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titel"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Ontwikkelaar (optioneel)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Programmabestand"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Bestand selecteren"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Meer info"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Bewerken"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Verbergen"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Niet meer verbergen"
 
@@ -121,17 +121,17 @@ msgstr "Niet meer verbergen"
 msgid "General"
 msgstr "Algemeen"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Zoeken"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Ongedaan maken"
 
@@ -139,11 +139,11 @@ msgstr "Ongedaan maken"
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Zijbalk omschakelen"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Hoofdmenu"
 
@@ -151,12 +151,12 @@ msgstr "Hoofdmenu"
 msgid "Games"
 msgstr "Games"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Game toevoegen"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importeren"
 
@@ -168,8 +168,8 @@ msgstr "Verborgen games tonen"
 msgid "Remove Game"
 msgstr "Game verwijderen"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Gedrag"
 
@@ -185,7 +185,7 @@ msgstr "Cover-afbeelding start game"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Wisselt het gedrag van de cover-afbeelding en de speelknop om"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Afbeeldingen"
 
@@ -202,137 +202,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Gevarenzone"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Alle games verwijderen"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Gedeïnstalleerde games verwijderen"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Bronnen"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Installatielocatie"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam-games importeren"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak-games importeren"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic-games importeren"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG-games importeren"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon-games importeren"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Gesideloade games importeren"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Systeem­locatie"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Gebruikers­locatie"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Game-launchers importeren"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Lokale apps"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Authenticatie"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-sleutel"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB gebruiken"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Afbeeldingen downloaden bij het toevoegen of importeren van games"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Voorkeur geven boven officiële afbeeldingen"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Voorkeur geven aan geanimeerde afbeeldingen"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Covers bijwerken"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Haal covers op voor games in uw bibliotheek"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Bijwerken"
 
@@ -360,135 +364,136 @@ msgstr "Geen verborgen games"
 msgid "Games you hide will appear here"
 msgstr "Games die u verbergt zullen hier verschijnen"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Alle games"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Toegevoegd"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Geïmporteerd"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Verborgen games"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Game-titel"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Spelen"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sorteren"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Nieuwste"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Oudste"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Laatst gespeeld"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Verborgen games tonen"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Over Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} gestart"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Philip Goto https://flipflop97.github.io/"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Toegevoegd op {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nooit"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Laatst gespeeld: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Toepassen"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Nieuwe game toevoegen"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Toevoegen"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Programmabestanden"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "bestand.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programma"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\pad\\naar\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/pad/naar/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "Indien het pad spaties bevat, zorg er dan voor dat er dubbele "
 "aanhalingstekens omheen staan!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Kon game niet toevoegen"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Game-titel mag niet leeg zijn."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Programmabestand mag niet leeg zijn."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Kon voorkeuren niet toepassen"
 
@@ -538,51 +543,50 @@ msgid "{} unhidden"
 msgstr "{} hersteld"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} verwijderd"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Alle games verwijderd"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Een API-sleutel is vereist om SteamGridDB te gebruiken. U kunt er {}hier{} "
 "één genereren."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Covers downloaden…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Covers bijgewerkt"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installatie niet gevonden"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Selecteer een geldige map"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Ongeldige map"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Locatie instellen"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Sluiten"
 
@@ -590,27 +594,29 @@ msgstr "Sluiten"
 msgid "Importing Games…"
 msgstr "Games importeren…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "De volgende fouten zijn opgetreden tijdens het importeren:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Geen nieuwe games gevonden"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 game geïmporteerd"
+msgid_plural "{} games imported"
+msgstr[0] "1 game geïmporteerd"
+msgstr[1] "{} games geïmporteerd"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} games geïmporteerd"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 verwijderd"
+msgid_plural "{} removed"
+msgstr[0] "1 verwijderd"
+msgstr[1] "{} verwijderd"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -647,6 +653,9 @@ msgstr "Kan SteamGridDB niet authenticeren"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifieer uw API-sleutel onder voorkeuren"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} games geïmporteerd"
 
 #~ msgid "Cache Location"
 #~ msgstr "Cache-locatie"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-05-15 14:01+0000\n"
 "Last-Translator: Karol <k.derbotprogramista@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/cartridges/"
@@ -447,11 +447,10 @@ msgstr ""
 msgid "{} launched"
 msgstr "{} uruchomiony"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
-msgstr "kredyty tłumacza"
+msgstr ""
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-05-15 14:01+0000\n"
 "Last-Translator: Karol <k.derbotprogramista@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/cartridges/"
@@ -69,7 +69,7 @@ msgstr "Edycja szczegółów gry"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferencje"
 
@@ -135,7 +135,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiszy"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Wróć"
 
@@ -174,7 +174,7 @@ msgid "Remove Game"
 msgstr "Usuń Grę"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Zachowanie"
 
@@ -210,140 +210,140 @@ msgstr "Strefa zagrożenia"
 msgid "Remove All Games"
 msgstr "Usuń wszystkie gry"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Usuń Odinstalowane Gry"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Źródła"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Lokalizacja instalacji"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importuj gry Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importuj gry Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importuj gry Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importuj gry z GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importuj gry Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importuj gry w wersji Sideloaded"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Butelki"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendarne"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 #, fuzzy
 msgid "System Location"
 msgstr "Ustaw położenie"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 #, fuzzy
 msgid "User Location"
 msgstr "Ustaw położenie"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importuj programy uruchamiające gry"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Klucz API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Użyj SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Pobieranie obrazów podczas dodawania lub importowania gier"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferuj ponad Oficjalne zdjęcia"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferuj animowane obrazy"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 #, fuzzy
 msgid "Update Covers"
 msgstr "Usuń osłonę"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr ""
 
@@ -554,47 +554,47 @@ msgstr "{} nieukryty"
 msgid "{} removed"
 msgstr "{} usunięty"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Wszystkie gry usunięte"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Do korzystania z SteamGridDB wymagany jest klucz API. Możesz go wygenerować "
 "{} tutaj{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 #, fuzzy
 msgid "Downloading covers…"
 msgstr "Importowanie okładek…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Nie znaleziono instalacji"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Wybierz prawidłowy katalog"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr ""
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Nieprawidłowy katalog"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Ustaw położenie"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Odrzucić"
 
@@ -602,17 +602,17 @@ msgstr "Odrzucić"
 msgid "Importing Games…"
 msgstr "Importowanie gier…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 #, fuzzy
 msgid "No new games found"
 msgstr "Nie znaleziono żadnych gier"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -621,7 +621,7 @@ msgstr[1] "{} Importowana"
 msgstr[2] "{} Importowana"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-05-15 14:01+0000\n"
 "Last-Translator: Karol <k.derbotprogramista@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/cartridges/"
@@ -550,9 +550,14 @@ msgid "{} unhidden"
 msgstr "{} nieukryty"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} usunięty"
+msgid_plural "{} removed"
+msgstr[0] "{} usunięty"
+msgstr[1] "{} usunięty"
+msgstr[2] "{} usunięty"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -598,6 +603,32 @@ msgstr "Ustaw położenie"
 msgid "Dismiss"
 msgstr "Odrzucić"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Dzisiaj"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Wczoraj"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Ostatnio odtwarzane"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Ostatnio odtwarzane"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importowanie gier…"
@@ -614,20 +645,11 @@ msgstr "Nie znaleziono żadnych gier"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "{} Importowana"
-msgstr[1] "{} Importowana"
-msgstr[2] "{} Importowana"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "{} usunięty"
-msgstr[1] "{} usunięty"
-msgstr[2] "{} usunięty"
+msgstr[0] "Gry Przywiezione"
+msgstr[1] "Gry Przywiezione"
+msgstr[2] "Gry Przywiezione"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -666,8 +688,18 @@ msgid "Verify your API key in preferences"
 msgstr "Zweryfikuj swój klucz API w preferencjach"
 
 #, fuzzy
-#~ msgid "{} games imported"
-#~ msgstr "Gry Przywiezione"
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "{} Importowana"
+#~ msgstr[1] "{} Importowana"
+#~ msgstr[2] "{} Importowana"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "{} usunięty"
+#~ msgstr[1] "{} usunięty"
+#~ msgstr[2] "{} usunięty"
 
 #~ msgid "Cache Location"
 #~ msgstr "Lokalizacja pamięci podręcznej"
@@ -737,12 +769,6 @@ msgstr "Zweryfikuj swój klucz API w preferencjach"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Butelki Miejsce montażu"
-
-#~ msgid "Today"
-#~ msgstr "Dzisiaj"
-
-#~ msgid "Yesterday"
-#~ msgstr "Wczoraj"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Wybierz katalog pamięci podręcznej Lutris."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-05-15 14:01+0000\n"
 "Last-Translator: Karol <k.derbotprogramista@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/cartridges/"
@@ -58,8 +58,8 @@ msgstr ""
 "wsparcie dla importu gier ze Steam, Lutris, Heroic i innych bez konieczności "
 "logowania. Możesz sortować i ukrywać gry lub pobierać okładki ze SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Szczegóły gry"
 
@@ -68,8 +68,8 @@ msgid "Edit Game Details"
 msgstr "Edycja szczegółów gry"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferencje"
 
@@ -77,47 +77,47 @@ msgstr "Preferencje"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nowa okładka"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Usuń okładkę"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Tytuł"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Twórca lub wydawca (opcjonalnie)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Plik wykonywalny"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Wybierz Plik"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Więcej informacji"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Edytuj"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Ukryj"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Usuń"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Odkryj"
 
@@ -125,17 +125,17 @@ msgstr "Odkryj"
 msgid "General"
 msgstr "Ogólne"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Szukaj"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiszy"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Wróć"
 
@@ -143,12 +143,12 @@ msgstr "Wróć"
 msgid "Quit"
 msgstr "Wyjdź"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 #, fuzzy
 msgid "Toggle Sidebar"
 msgstr "przełącz pasek boczny"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menu główne"
 
@@ -156,12 +156,12 @@ msgstr "Menu główne"
 msgid "Games"
 msgstr "Gry"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Dodaj grę"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importuj"
 
@@ -173,8 +173,8 @@ msgstr "Pokaż Ukryte Gry"
 msgid "Remove Game"
 msgstr "Usuń Grę"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Zachowanie"
 
@@ -190,7 +190,7 @@ msgstr "Obraz okładki uruchamia grę"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Zamienia zachowanie obrazu okładki i przycisku odtwarzania"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Obrazy"
 
@@ -206,140 +206,144 @@ msgstr "Zapisywanie okładek gier bezstratnie kosztem pamięci masowej"
 msgid "Danger Zone"
 msgstr "Strefa zagrożenia"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Usuń wszystkie gry"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Usuń Odinstalowane Gry"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Źródła"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Lokalizacja instalacji"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importuj gry Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importuj gry Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importuj gry Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importuj gry z GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importuj gry Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importuj gry w wersji Sideloaded"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Butelki"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendarne"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 #, fuzzy
 msgid "System Location"
 msgstr "Ustaw położenie"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 #, fuzzy
 msgid "User Location"
 msgstr "Ustaw położenie"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importuj programy uruchamiające gry"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Klucz API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Użyj SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Pobieranie obrazów podczas dodawania lub importowania gier"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferuj ponad Oficjalne zdjęcia"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Preferuj animowane obrazy"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 #, fuzzy
 msgid "Update Covers"
 msgstr "Usuń osłonę"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr ""
 
@@ -367,138 +371,139 @@ msgstr "Brak ukrytych gier"
 msgid "Games you hide will appear here"
 msgstr "Gry, które ukryjesz, pojawią się tutaj"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 #, fuzzy
 msgid "All Games"
 msgstr "Usuń wszystkie gry"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 #, fuzzy
 msgid "Added"
 msgstr "Dodano: {}"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 #, fuzzy
 msgid "Imported"
 msgstr "Importuj"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Ukryte gry"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Tytuł gry"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Graj"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sortuj"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Najnowsza"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Najstarszy"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Ostatnio odtwarzane"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Pokaż ukryte"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "O Kartridżach"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr ""
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr ""
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} uruchomiony"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "kredyty tłumacza"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Dodano: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nigdy"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Ostatnio grane: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Dodaj nową Grę"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr ""
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Pliki wykonywalne"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "plik.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\scieżka\\do\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/ścieżka/do/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -520,19 +525,19 @@ msgstr ""
 "\n"
 "Jeśli ścieżka zawiera spacje, pamiętaj, aby zawinąć ją w podwójne cudzysłowy!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Nie można było dodać gry"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Tytuł gry nie może być pusty."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Plik wykonywalny nie może być pusty."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Nie można zastosować preferencji"
 
@@ -546,52 +551,51 @@ msgid "{} unhidden"
 msgstr "{} nieukryty"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} usunięty"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Wszystkie gry usunięte"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Do korzystania z SteamGridDB wymagany jest klucz API. Możesz go wygenerować "
 "{} tutaj{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 #, fuzzy
 msgid "Downloading covers…"
 msgstr "Importowanie okładek…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Nie znaleziono instalacji"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Wybierz prawidłowy katalog"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr ""
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Nieprawidłowy katalog"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Ustaw położenie"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Odrzucić"
 
@@ -599,31 +603,32 @@ msgstr "Odrzucić"
 msgid "Importing Games…"
 msgstr "Importowanie gier…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 #, fuzzy
 msgid "No new games found"
 msgstr "Nie znaleziono żadnych gier"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
 #, fuzzy
 msgid "1 game imported"
-msgstr "Gra Importowana"
+msgid_plural "{} games imported"
+msgstr[0] "{} Importowana"
+msgstr[1] "{} Importowana"
+msgstr[2] "{} Importowana"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-#, fuzzy
-msgid "{} games imported"
-msgstr "Gry Przywiezione"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
 #, fuzzy
 msgid "1 removed"
-msgstr "{} usunięty"
+msgid_plural "{} removed"
+msgstr[0] "{} usunięty"
+msgstr[1] "{} usunięty"
+msgstr[2] "{} usunięty"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -660,6 +665,10 @@ msgstr "Nie można uwierzytelnić SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Zweryfikuj swój klucz API w preferencjach"
+
+#, fuzzy
+#~ msgid "{} games imported"
+#~ msgstr "Gry Przywiezione"
 
 #~ msgid "Cache Location"
 #~ msgstr "Lokalizacja pamięci podręcznej"

--- a/po/pt.po
+++ b/po/pt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/cartridges/"
@@ -439,9 +439,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} iniciado"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Pedro Sader Azevedo"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/cartridges/"
@@ -57,8 +57,8 @@ msgstr ""
 "necessidade de login. Você pode classificar e ocultar jogos ou baixar a capa "
 "do SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalhes do jogo"
 
@@ -67,8 +67,8 @@ msgid "Edit Game Details"
 msgstr "Editar detalhes do jogo"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -76,47 +76,47 @@ msgstr "Preferências"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nova capa"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Apagar capa"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Título"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Programador (opcional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Executável"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Selecionar ficheiro"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Mais informação"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Editar"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Ocultar"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Remover"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Exibir"
 
@@ -124,17 +124,17 @@ msgstr "Exibir"
 msgid "General"
 msgstr "Geral"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Buscar"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -142,11 +142,11 @@ msgstr "Desfazer"
 msgid "Quit"
 msgstr "Sair"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Alternar barra lateral"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -154,12 +154,12 @@ msgstr "Menu principal"
 msgid "Games"
 msgstr "Jogos"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Adicionar jogo"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importar"
 
@@ -171,8 +171,8 @@ msgstr "Exibir jogos ocultos"
 msgid "Remove Game"
 msgstr "Remover jogo"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -188,7 +188,7 @@ msgstr "Clicar na capa inicia o jogo"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Troca o comportamento de clicar na capa do jogo e do botão Jogar"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Imagens"
 
@@ -204,137 +204,141 @@ msgstr "Salva imagens das capas sem perda, consumindo mais armazenamento"
 msgid "Danger Zone"
 msgstr "Zona de perigo"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Remover todos os jogos"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Remover jogos desinstalados"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Fontes"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Local de instalação"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importar jogos da Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importar jogos do Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importar jogos da Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importar jogos do GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importar jogos da Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importar jogos adicionados manualmente"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Lendário"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Local dos Dados no Sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Local dos Dados de Utilizador"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importar iniciadores de jogos"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas desktop"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Chave da API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Baixa imagens ao adicionar ou importar jogos"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferir mais que as imagens oficiais"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Preferir imagens animadas"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Atualizar capas"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Obter capas para jogos que já estão na sua biblioteca"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Atualizar"
 
@@ -362,135 +366,136 @@ msgstr "Sem jogos ocultados"
 msgid "Games you hide will appear here"
 msgstr "Jogos ocultados vão aparecer aqui"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Todos os jogos"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Adicionado"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importado"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Jogos ocultados"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Título do jogo"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Jogar"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordenar"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Mais novo"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Mais antigo"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Jogou pela última vez"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Mostrar ocultados"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Sobre o Cartuchos"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} iniciado"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Pedro Sader Azevedo"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Adicionado: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nunca"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Jogou pela última vez: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Aplicar"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Adicionar novo jogo"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Adicionar"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Executáveis"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "arquivo.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programa"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\caminho\\para\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/caminho/para/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "\n"
 "Se o caminho contiver espaços, certifique-se de colocá-lo entre aspas duplas!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Não foi possível adicionar o jogo"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "O título do jogo não pode estar vazio."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "O executável não pode estar vazio."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Não foi possível aplicar as preferências"
 
@@ -538,51 +543,50 @@ msgid "{} unhidden"
 msgstr "{} está exposto"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} removido"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Todos os jogos foram removidos"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Uma chave da API é necessária para usar a SteamGridDB. Você pode gerar uma "
 "chave {}aqui{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "A descarregar capas…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Capas atualizadas"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Instalação não encontrada"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Selecione um diretório válido"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Atenção"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Diretório inválido"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Definir local"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -590,27 +594,29 @@ msgstr "Dispensar"
 msgid "Importing Games…"
 msgstr "Importando jogos…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Ocorreram os seguintes erros durante a importação:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nenhum jogo novo encontrado"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 jogo importado"
+msgid_plural "{} games imported"
+msgstr[0] "1 jogo importado"
+msgstr[1] "{} jogos importados"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} jogos importados"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 removido"
+msgid_plural "{} removed"
+msgstr[0] "1 removido"
+msgstr[1] "{} removidos"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -647,6 +653,9 @@ msgstr "Não foi possível autenticar no SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifique a sua chave de API nas preferências"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} jogos importados"
 
 #~ msgid "Cache Location"
 #~ msgstr "Local do cache"

--- a/po/pt.po
+++ b/po/pt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/cartridges/"
@@ -542,9 +542,13 @@ msgid "{} unhidden"
 msgstr "{} está exposto"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} removido"
+msgid_plural "{} removed"
+msgstr[0] "{} removido"
+msgstr[1] "{} removido"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -589,6 +593,32 @@ msgstr "Definir local"
 msgid "Dismiss"
 msgstr "Dispensar"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Hoje"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Ontem"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Jogou pela última vez"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Jogou pela última vez"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importando jogos…"
@@ -604,18 +634,10 @@ msgstr "Nenhum jogo novo encontrado"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 jogo importado"
+msgstr[0] "{} jogos importados"
 msgstr[1] "{} jogos importados"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 removido"
-msgstr[1] "{} removidos"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -653,8 +675,17 @@ msgstr "Não foi possível autenticar no SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifique a sua chave de API nas preferências"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} jogos importados"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 jogo importado"
+#~ msgstr[1] "{} jogos importados"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 removido"
+#~ msgstr[1] "{} removidos"
 
 #~ msgid "Cache Location"
 #~ msgstr "Local do cache"
@@ -723,12 +754,6 @@ msgstr "Verifique a sua chave de API nas preferências"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Local de instalação do Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Hoje"
-
-#~ msgid "Yesterday"
-#~ msgstr "Ontem"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Cache não encontrado"

--- a/po/pt.po
+++ b/po/pt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/cartridges/"
@@ -68,7 +68,7 @@ msgstr "Editar detalhes do jogo"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -134,7 +134,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -172,7 +172,7 @@ msgid "Remove Game"
 msgstr "Remover jogo"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -208,137 +208,137 @@ msgstr "Zona de perigo"
 msgid "Remove All Games"
 msgstr "Remover todos os jogos"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Remover jogos desinstalados"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Fontes"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Local de instalação"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importar jogos da Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importar jogos do Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importar jogos da Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importar jogos do GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importar jogos da Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importar jogos adicionados manualmente"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Lendário"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Local dos Dados no Sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Local dos Dados de Utilizador"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importar iniciadores de jogos"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas desktop"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Chave da API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Baixa imagens ao adicionar ou importar jogos"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferir mais que as imagens oficiais"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferir imagens animadas"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Atualizar capas"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Obter capas para jogos que já estão na sua biblioteca"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Atualizar"
 
@@ -546,46 +546,46 @@ msgstr "{} está exposto"
 msgid "{} removed"
 msgstr "{} removido"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Todos os jogos foram removidos"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Uma chave da API é necessária para usar a SteamGridDB. Você pode gerar uma "
 "chave {}aqui{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "A descarregar capas…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Capas atualizadas"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalação não encontrada"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Selecione um diretório válido"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Atenção"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Diretório inválido"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Definir local"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -593,16 +593,16 @@ msgstr "Dispensar"
 msgid "Importing Games…"
 msgstr "Importando jogos…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Ocorreram os seguintes erros durante a importação:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nenhum jogo novo encontrado"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[0] "1 jogo importado"
 msgstr[1] "{} jogos importados"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-04-20 05:07+0000\n"
 "Last-Translator: Filipe Motta <luiz_filipe_motta@hotmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -68,7 +68,7 @@ msgstr "Editar detalhes do jogo"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -134,7 +134,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -172,7 +172,7 @@ msgid "Remove Game"
 msgstr "Remover jogo"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -208,137 +208,137 @@ msgstr "Zona de Perigo"
 msgid "Remove All Games"
 msgstr "Remover todos os jogos"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Remover jogos desinstalados"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Fontes"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Local de instalação"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importar jogos do Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importar jogos do Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importar jogos da Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importar jogos do GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importar jogos da Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importar jogos adicionados manualmente"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Garrafas"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Lendário"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Local dos Dados no Sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Local dos Dados de Usuário"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importar iniciadores de jogos"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas desktop"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Chave da API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Baixar imagens ao adicionar ou importar jogos"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferir mais que as imagens oficiais"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferir imagens animadas"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Atualizar capas"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Obter capas para jogos que já estão na sua biblioteca"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Atualizar"
 
@@ -549,46 +549,46 @@ msgstr "{} exibido"
 msgid "{} removed"
 msgstr "{} removido"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Todos os jogos foram removidos"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Uma chave de API é necessária para utilizar o SteamGridDB. Você pode gerar "
 "uma {}aqui{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Baixando capas…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Capas atualizadas"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalação não encontrada"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Selecione um diretório válido"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Atenção"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Diretório inválido"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Definir local"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -596,16 +596,16 @@ msgstr "Dispensar"
 msgid "Importing Games…"
 msgstr "Importando jogos…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Ocorreram os seguintes erros durante a importação:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nenhum jogo novo encontrado"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -613,7 +613,7 @@ msgstr[0] "1 jogo importado"
 msgstr[1] "{} jogos importados"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-04-20 05:07+0000\n"
 "Last-Translator: Filipe Motta <luiz_filipe_motta@hotmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -57,8 +57,8 @@ msgstr ""
 "necessidade de login. Você pode ordenar e esconder jogos ou baixar arte de "
 "capa do SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalhes do jogo"
 
@@ -67,8 +67,8 @@ msgid "Edit Game Details"
 msgstr "Editar detalhes do jogo"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -76,47 +76,47 @@ msgstr "Preferências"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nova capa"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Excluir capa"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Título"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Desenvolvedor (opcional)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Executável"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Selecionar arquivo"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Mais informações"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Editar"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Esconder"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Remover"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Exibir"
 
@@ -124,17 +124,17 @@ msgstr "Exibir"
 msgid "General"
 msgstr "Geral"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Buscar"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -142,11 +142,11 @@ msgstr "Desfazer"
 msgid "Quit"
 msgstr "Sair"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Alternar barra lateral"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Menu Principal"
 
@@ -154,12 +154,12 @@ msgstr "Menu Principal"
 msgid "Games"
 msgstr "Jogos"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Adicionar jogo"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importar"
 
@@ -171,8 +171,8 @@ msgstr "Exibir jogos ocultos"
 msgid "Remove Game"
 msgstr "Remover jogo"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -188,7 +188,7 @@ msgstr "Imagem da capa inicia o jogo"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Troca o comportamento da imagem da capa e do botão jogar"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Imagens"
 
@@ -204,137 +204,141 @@ msgstr "Salva capas de jogos sem perdas, consumindo mais armazenamento"
 msgid "Danger Zone"
 msgstr "Zona de Perigo"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Remover todos os jogos"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Remover jogos desinstalados"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Fontes"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Local de instalação"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importar jogos do Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importar jogos do Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importar jogos da Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importar jogos do GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importar jogos da Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importar jogos adicionados manualmente"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Garrafas"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Lendário"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Local dos Dados no Sistema"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Local dos Dados de Usuário"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importar iniciadores de jogos"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Entradas desktop"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Chave da API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Usar SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Baixar imagens ao adicionar ou importar jogos"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Preferir mais que as imagens oficiais"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Preferir imagens animadas"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Atualizar capas"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Obter capas para jogos que já estão na sua biblioteca"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Atualizar"
 
@@ -362,137 +366,138 @@ msgstr "Sem jogos ocultos"
 msgid "Games you hide will appear here"
 msgstr "Os jogos ocultos aparecerão aqui"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Todos os jogos"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Adicionado"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importado"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Jogos ocultos"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Título do jogo"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Jogar"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Ordenar"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Mais novo"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Mais antigo"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Última vez jogado"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Mostrar ocultados"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Sobre o Cartuchos"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} iniciado"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr ""
 "Pedro Sader Azevedo, Vinícius \"Stalck\", Filipe Motta "
 "<luizfilipemotta@gmail.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Adicionado: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Nunca"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Jogado pela última vez: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Aplicar"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Adicionar novo jogo"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Adicionar"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Executáveis"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "arquivo.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "programa"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\caminho\\para\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/caminho/para/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -514,19 +519,19 @@ msgstr ""
 "\n"
 "Se o caminho contiver espaços, certifique-se de colocá-lo entre aspas duplas!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Não foi possível adicionar o jogo"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "O título do jogo não pode estar vazio."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "O executável não pode estar vazio."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Não foi possível aplicar as preferências"
 
@@ -540,51 +545,50 @@ msgid "{} unhidden"
 msgstr "{} exibido"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} removido"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Todos os jogos foram removidos"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Uma chave de API é necessária para utilizar o SteamGridDB. Você pode gerar "
 "uma {}aqui{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Baixando capas…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Capas atualizadas"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Instalação não encontrada"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Selecione um diretório válido"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Atenção"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Diretório inválido"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Definir local"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -592,27 +596,29 @@ msgstr "Dispensar"
 msgid "Importing Games…"
 msgstr "Importando jogos…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Ocorreram os seguintes erros durante a importação:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Nenhum jogo novo encontrado"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 jogo importado"
+msgid_plural "{} games imported"
+msgstr[0] "1 jogo importado"
+msgstr[1] "{} jogos importados"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} jogos importados"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 removido"
+msgid_plural "{} removed"
+msgstr[0] "1 removido"
+msgstr[1] "{} removidos"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -649,6 +655,9 @@ msgstr "Não foi possível autenticar no SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifique sua chave de API nas preferências"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} jogos importados"
 
 #~ msgid "Cache Location"
 #~ msgstr "Local do cache"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-04-20 05:07+0000\n"
 "Last-Translator: Filipe Motta <luiz_filipe_motta@hotmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -545,9 +545,13 @@ msgid "{} unhidden"
 msgstr "{} exibido"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} removido"
+msgid_plural "{} removed"
+msgstr[0] "{} removido"
+msgstr[1] "{} removido"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -592,6 +596,32 @@ msgstr "Definir local"
 msgid "Dismiss"
 msgstr "Dispensar"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Hoje"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Ontem"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Última vez jogado"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Última vez jogado"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importando jogos…"
@@ -607,18 +637,10 @@ msgstr "Nenhum jogo novo encontrado"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 jogo importado"
+msgstr[0] "{} jogos importados"
 msgstr[1] "{} jogos importados"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 removido"
-msgstr[1] "{} removidos"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -656,8 +678,17 @@ msgstr "Não foi possível autenticar no SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifique sua chave de API nas preferências"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} jogos importados"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 jogo importado"
+#~ msgstr[1] "{} jogos importados"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 removido"
+#~ msgstr[1] "{} removidos"
 
 #~ msgid "Cache Location"
 #~ msgstr "Local do cache"
@@ -722,12 +753,6 @@ msgstr "Verifique sua chave de API nas preferências"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Local de instalação do Garrafas"
-
-#~ msgid "Today"
-#~ msgstr "Hoje"
-
-#~ msgid "Yesterday"
-#~ msgstr "Ontem"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Selecione o diretório de cache do Lutris."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-04-20 05:07+0000\n"
 "Last-Translator: Filipe Motta <luiz_filipe_motta@hotmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -439,13 +439,13 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} iniciado"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr ""
-"Pedro Sader Azevedo, Vinícius \"Stalck\", Filipe Motta "
-"<luizfilipemotta@gmail.com>"
+"Pedro Sader Azevedo\n"
+"Vinícius \"Stalck\"\n"
+"Filipe Motta <luizfilipemotta@gmail.com>"
 
 #. The variable is the date when the game was added
 #: cartridges/window.py:382

--- a/po/ro.po
+++ b/po/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-04-04 17:12+0000\n"
 "Last-Translator: Matt C <matei.gurzu@gmail.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/cartridges/"
@@ -439,7 +439,7 @@ msgstr ""
 msgid "{} launched"
 msgstr ""
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
 msgid "translator-credits"
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-04-04 17:12+0000\n"
 "Last-Translator: Matt C <matei.gurzu@gmail.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/cartridges/"
@@ -52,8 +52,8 @@ msgstr ""
 "jocurilor dvs. din Steam, Heroic și Bottles cu funcții de organizare, cum ar "
 "fi ascunderea și sortarea după data adăugată sau ultima dată jucată."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Detalii joc"
 
@@ -62,8 +62,8 @@ msgid "Edit Game Details"
 msgstr "Editați detaliile jocului"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Preferințe"
 
@@ -71,47 +71,47 @@ msgstr "Preferințe"
 msgid "Cancel"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr ""
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr ""
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr ""
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr ""
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr ""
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr ""
 
@@ -119,17 +119,17 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Căutare"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Meniu principal"
 
@@ -149,12 +149,12 @@ msgstr "Meniu principal"
 msgid "Games"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Adăugați joc"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr ""
 
@@ -168,8 +168,8 @@ msgstr "Fără jocuri ascunse"
 msgid "Remove Game"
 msgstr "Fără jocuri"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr ""
 
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr ""
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr ""
 
@@ -201,139 +201,143 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr ""
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr ""
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr ""
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr ""
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 #, fuzzy
 msgid "Import Amazon Games"
 msgstr "Lansator de jocuri"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr ""
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr ""
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr ""
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr ""
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr ""
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr ""
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr ""
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr ""
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 #, fuzzy
 msgid "Import Game Launchers"
 msgstr "Lansator de jocuri"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr ""
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr ""
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr ""
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr ""
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr ""
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr ""
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr ""
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr ""
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr ""
 
@@ -361,136 +365,136 @@ msgstr "Fără jocuri ascunse"
 msgid "Games you hide will appear here"
 msgstr "Jocurile pe care le ascundeți vor apărea aici"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 #, fuzzy
 msgid "All Games"
 msgstr "Fără jocuri"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr ""
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr ""
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Jocuri ascunse"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Titlul jocului"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Joacă"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr ""
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr ""
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr ""
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr ""
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr ""
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr ""
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr ""
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr ""
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr ""
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr ""
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr ""
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr ""
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+msgid "translator-credits"
 msgstr ""
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr ""
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr ""
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr ""
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr ""
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr ""
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr ""
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr ""
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr ""
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr ""
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -503,19 +507,19 @@ msgid ""
 "If the path contains spaces, make sure to wrap it in double quotes!"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr ""
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr ""
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr ""
 
@@ -529,49 +533,48 @@ msgid "{} unhidden"
 msgstr ""
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr ""
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr ""
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr ""
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr ""
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr ""
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr ""
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr ""
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr ""
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr ""
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr ""
 
@@ -580,28 +583,30 @@ msgstr ""
 msgid "Importing Games…"
 msgstr "Lansator de jocuri"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr ""
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 #, fuzzy
 msgid "No new games found"
 msgstr "Nu s-au găsit jocuri"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
 msgid "1 game imported"
-msgstr ""
+msgid_plural "{} games imported"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr ""
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
 msgid "1 removed"
-msgstr ""
+msgid_plural "{} removed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-10-14 00:15+0000\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/cartridges/"
@@ -545,9 +545,14 @@ msgid "{} unhidden"
 msgstr "{} afișat"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} eliminat"
+msgid_plural "{} removed"
+msgstr[0] "{} eliminat"
+msgstr[1] "{} eliminat"
+msgstr[2] "{} eliminat"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -592,6 +597,32 @@ msgstr "Stabilește locația"
 msgid "Dismiss"
 msgstr "Revocare"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Jucat ultima dată"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Jucat ultima dată"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Se importă jocurile…"
@@ -606,19 +637,12 @@ msgstr "Nu s-au găsit jocuri noi"
 
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
-msgid "1 game imported"
+#, fuzzy
+msgid "{} game imported"
 msgid_plural "{} games imported"
 msgstr[0] "Un joc importat"
 msgstr[1] "{} jocuri importate"
 msgstr[2] "{} jocuri importate"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "Un joc eliminat"
-msgstr[1] ""
-msgstr[2] ""
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -655,6 +679,12 @@ msgstr "Nu s-a putut autentifica SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verificați cheia API în preferințe"
+
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "Un joc eliminat"
+#~ msgstr[1] ""
+#~ msgstr[2] ""
 
 #~ msgid "Library"
 #~ msgstr "Bibliotecă"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-10-14 00:15+0000\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/cartridges/"
@@ -40,8 +40,8 @@ msgstr "Lansați toate jocurile dvs"
 msgid ""
 "gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;legendary;retroarch;"
 msgstr ""
-"jocuri;lansator;gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;lege"
-"ndary;retroarch;"
+"jocuri;lansator;gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;"
+"legendary;retroarch;"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:12
 msgid ""
@@ -66,7 +66,7 @@ msgstr "Editați detaliile jocului"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Preferințe"
 
@@ -132,7 +132,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Taste de comenzi rapide"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Anulează"
 
@@ -170,7 +170,7 @@ msgid "Remove Game"
 msgstr "Elimină jocul"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Comportament"
 
@@ -209,137 +209,137 @@ msgstr "Zonă periculoasă"
 msgid "Remove All Games"
 msgstr "Elimină toate jocurile"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Elimină jocurile dezinstalate"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Surse"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Locația de instalare"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importă jocuri din Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importă jocuri din Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importă jocuri din Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importă jocuri din GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importă jocuri din Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importă jocuri descărcate manual"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Locația directorului de date la nivel de sistem"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Locația directorului de date specific utilizatorului"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importare lansatoare de jocuri"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Elemente de acces direct, pe birou"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autentificare"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Cheie API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Utilizează SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Descarcă imagini atunci când se adaugă sau se importă jocuri"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Preferă mai mult decât imaginile oficiale"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Preferă imaginile animate"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Actualizare coperți"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Obține coperți pentru jocurile aflate deja în colecție"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Actualizare"
 
@@ -367,7 +367,7 @@ msgstr "Fără jocuri ascunse"
 msgid "Games you hide will appear here"
 msgstr "Jocurile pe care le ascundeți vor apărea aici"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Toate jocurile"
 
@@ -549,46 +549,46 @@ msgstr "{} afișat"
 msgid "{} removed"
 msgstr "{} eliminat"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Toate jocurile au fost eliminate"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
-"O cheie API este necesară pentru a utiliza SteamGridDB. Puteți genera una "
-"{}aici{}."
+"O cheie API este necesară pentru a utiliza SteamGridDB. Puteți genera una {}"
+"aici{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Se descarcă coperțile…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Coperți actualizate"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Instalarea nu a fost găsită"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Selectați un director valid"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Atenţie"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Director nevalid"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Stabilește locația"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Revocare"
 
@@ -596,16 +596,16 @@ msgstr "Revocare"
 msgid "Importing Games…"
 msgstr "Se importă jocurile…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Au apărut următoarele erori în timpul importului:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Nu s-au găsit jocuri noi"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] "Un joc importat"
@@ -613,7 +613,7 @@ msgstr[1] "{} jocuri importate"
 msgstr[2] "{} jocuri importate"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 msgid "1 removed"
 msgid_plural "{} removed"
 msgstr[0] "Un joc eliminat"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Сергей <asvmail.as@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartridges/"
@@ -541,9 +541,14 @@ msgid "{} unhidden"
 msgstr "{} - не скрыта"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} удалена"
+msgid_plural "{} removed"
+msgstr[0] "{} удалена"
+msgstr[1] "{} удалена"
+msgstr[2] "{} удалена"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -588,6 +593,32 @@ msgstr "Установить расположение"
 msgid "Dismiss"
 msgstr "Отклонить"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Сегодня"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Вчера"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Последняя игра"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Последняя игра"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Импорт игр…"
@@ -603,20 +634,11 @@ msgstr "Новых игр не найдено"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 игра импортирована"
-msgstr[1] "{} игры импортировано"
-msgstr[2] "{} игры импортировано"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 удалена"
-msgstr[1] "{} удалено"
-msgstr[2] "{} удалено"
+msgstr[0] "{} игр(ы) импортировано"
+msgstr[1] "{} игр(ы) импортировано"
+msgstr[2] "{} игр(ы) импортировано"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -654,8 +676,19 @@ msgstr "Не удалось пройти аутентификацию SteamGridD
 msgid "Verify your API key in preferences"
 msgstr "Проверьте ключ API-ключ в параметрах"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} игр(ы) импортировано"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 игра импортирована"
+#~ msgstr[1] "{} игры импортировано"
+#~ msgstr[2] "{} игры импортировано"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 удалена"
+#~ msgstr[1] "{} удалено"
+#~ msgstr[2] "{} удалено"
 
 #~ msgid "Cache Location"
 #~ msgstr "Расположение кэша"
@@ -736,12 +769,6 @@ msgstr "Проверьте ключ API-ключ в параметрах"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Место установки Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Сегодня"
-
-#~ msgid "Yesterday"
-#~ msgstr "Вчера"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Кэш не найден"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Сергей <asvmail.as@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartridges/"
@@ -56,8 +56,8 @@ msgstr ""
 "систему. Вы можете сортировать и скрывать игры или загружать обложки из "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Подробности об игре"
 
@@ -66,8 +66,8 @@ msgid "Edit Game Details"
 msgstr "Редактировать подробности об игре"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -75,47 +75,47 @@ msgstr "Параметры"
 msgid "Cancel"
 msgstr "Отменить"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Новая обложка"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Удалить обложку"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Название"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Разработчик (необязательно)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Исполняемый"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Выбрать файл"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Дополнительная информация"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Редактировать"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Скрыть"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Удалить"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Показать"
 
@@ -123,17 +123,17 @@ msgstr "Показать"
 msgid "General"
 msgstr "Общее"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Поиск"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Комбинации клавиш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Вернуть"
 
@@ -141,11 +141,11 @@ msgstr "Вернуть"
 msgid "Quit"
 msgstr "Выйти"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Переключить боковую панель"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Главное меню"
 
@@ -153,12 +153,12 @@ msgstr "Главное меню"
 msgid "Games"
 msgstr "Игры"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Добавить игру"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Импорт"
 
@@ -170,8 +170,8 @@ msgstr "Показать скрытые игры"
 msgid "Remove Game"
 msgstr "Удалить игру"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Поведение"
 
@@ -187,7 +187,7 @@ msgstr "Запускать игры используя изображение о
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Меняет местами поведение изображения обложки и кнопки запуска"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Изображения"
 
@@ -203,137 +203,141 @@ msgstr "Сохранение обложек игр без потерь за сч
 msgid "Danger Zone"
 msgstr "Небезопасная область"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Удалить все игры"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Удалять деинсталлированные игры"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Источники"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Место установки"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Импорт игр Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Импорт игр Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Импорт игр Epic"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Импорт игр GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Импорт игр Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Импорт сторонних игр"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Расположение системного каталога"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Расположение каталога пользователя"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Импорт средств запуска игр"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Интеграция в среду рабочего стола"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-ключ"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Использовать SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Загрузка изображений при добавлении или импорте игр"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Отдавать предпочтение официальным изображениям"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Отдавать предпочтение анимированным изображениям"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Обновить обложки"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Получите обложки для игр, которые уже есть в вашей библиотеке"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Обновить"
 
@@ -361,135 +365,136 @@ msgstr "Нет скрытых игр"
 msgid "Games you hide will appear here"
 msgstr "Здесь появятся скрытые игры"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Все игры"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Добавлено"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Импортировано"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Скрытые игры"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Название игры"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Играть"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Сортировать"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "А-Я"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Я-А"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Сначала новые"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Сначала старые"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Последняя игра"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Показать скрытые"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "О приложении"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} - запущена"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Ser82-png"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Добавлено: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Никогда"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Последний раз запускалась: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Применить"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Добавить новую игру"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Добавить"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Исполняемые"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "программа"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\путь\\к\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/путь/к/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -511,19 +516,19 @@ msgstr ""
 "\n"
 "Если путь содержит пробелы, обязательно заключите его в двойные кавычки!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Не удалось добавить игру"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Название игры не может быть пустым."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Исполняемый файл не может быть пустым."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Не удалось применить параметры"
 
@@ -537,51 +542,50 @@ msgid "{} unhidden"
 msgstr "{} - не скрыта"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} удалена"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Все игры удалены"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для использования SteamGridDB требуется ключ API. Вы можете сгенерировать "
 "его {}здесь{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Скачивание обложек…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Обложки обновлены"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Установка не найдена"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Выберите действующий каталог"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Неверный каталог"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Установить расположение"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Отклонить"
 
@@ -589,27 +593,31 @@ msgstr "Отклонить"
 msgid "Importing Games…"
 msgstr "Импорт игр…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "При импорте возникли следующие ошибки:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Новых игр не найдено"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 игра импортирована"
+msgid_plural "{} games imported"
+msgstr[0] "1 игра импортирована"
+msgstr[1] "{} игры импортировано"
+msgstr[2] "{} игры импортировано"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} игр(ы) импортировано"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 удалена"
+msgid_plural "{} removed"
+msgstr[0] "1 удалена"
+msgstr[1] "{} удалено"
+msgstr[2] "{} удалено"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -646,6 +654,9 @@ msgstr "Не удалось пройти аутентификацию SteamGridD
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Проверьте ключ API-ключ в параметрах"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} игр(ы) импортировано"
 
 #~ msgid "Cache Location"
 #~ msgstr "Расположение кэша"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Сергей <asvmail.as@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartridges/"
@@ -67,7 +67,7 @@ msgstr "Редактировать подробности об игре"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -133,7 +133,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Комбинации клавиш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Вернуть"
 
@@ -171,7 +171,7 @@ msgid "Remove Game"
 msgstr "Удалить игру"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Поведение"
 
@@ -207,137 +207,137 @@ msgstr "Небезопасная область"
 msgid "Remove All Games"
 msgstr "Удалить все игры"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Удалять деинсталлированные игры"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Источники"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Место установки"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Импорт игр Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Импорт игр Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Импорт игр Epic"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Импорт игр GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Импорт игр Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Импорт сторонних игр"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Расположение системного каталога"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Расположение каталога пользователя"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Импорт средств запуска игр"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Интеграция в среду рабочего стола"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-ключ"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Использовать SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Загрузка изображений при добавлении или импорте игр"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Отдавать предпочтение официальным изображениям"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Отдавать предпочтение анимированным изображениям"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Обновить обложки"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Получите обложки для игр, которые уже есть в вашей библиотеке"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Обновить"
 
@@ -545,46 +545,46 @@ msgstr "{} - не скрыта"
 msgid "{} removed"
 msgstr "{} удалена"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Все игры удалены"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для использования SteamGridDB требуется ключ API. Вы можете сгенерировать "
 "его {}здесь{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Скачивание обложек…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Обложки обновлены"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Установка не найдена"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Выберите действующий каталог"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Неверный каталог"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Установить расположение"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Отклонить"
 
@@ -592,16 +592,16 @@ msgstr "Отклонить"
 msgid "Importing Games…"
 msgstr "Импорт игр…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "При импорте возникли следующие ошибки:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Новых игр не найдено"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -610,7 +610,7 @@ msgstr[1] "{} игры импортировано"
 msgstr[2] "{} игры импортировано"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: Сергей <asvmail.as@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartridges/"
@@ -438,9 +438,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} - запущена"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Ser82-png"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: bittin1ddc447d824349b2 <bittin@reimu.nl>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/cartridges/"
@@ -55,8 +55,8 @@ msgstr ""
 "importera spel från Steam, Lutris, Heroic och fler utan inloggning. Du kan "
 "sortera och dölja spel eller ladda ner omslagsbilder från SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Speldetaljer"
 
@@ -65,8 +65,8 @@ msgid "Edit Game Details"
 msgstr "Redigera speldetaljer"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Inställningar"
 
@@ -74,47 +74,47 @@ msgstr "Inställningar"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Nytt omslag"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Ta bort omslag"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Titel"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Utvecklare (valfritt)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Körbar"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Välj fil"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Mer info"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Redigera"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Dölj"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Ta bort"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Visa"
 
@@ -122,17 +122,17 @@ msgstr "Visa"
 msgid "General"
 msgstr "Allmänt"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Sök"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Tangentbordsgenvägar"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Ångra"
 
@@ -140,11 +140,11 @@ msgstr "Ångra"
 msgid "Quit"
 msgstr "Avsluta"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Växla sidofält"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Huvudmeny"
 
@@ -152,12 +152,12 @@ msgstr "Huvudmeny"
 msgid "Games"
 msgstr "Spel"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Lägg till spel"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Importera"
 
@@ -169,8 +169,8 @@ msgstr "Visa dolda spel"
 msgid "Remove Game"
 msgstr "Ta bort spel"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Beteende"
 
@@ -186,7 +186,7 @@ msgstr "Omslagsbild startar spel"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Byt beteende för omslagsbilden och Spela-knappen"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Bilder"
 
@@ -203,137 +203,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Farozon"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Ta bort alla spel"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Ta bort avinstallerade spel"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Källor"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Plats för installation"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Importera Steam-spel"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Importera Flatpak-spel"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Importera Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Importera GOG-spel"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Importera Amazon-spel"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Importera sidoladdade spel"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "System plats"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Användar plats"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Importera spelstartare"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Skrivbordsposter"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API-nyckel"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Använd SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Ladda ner bilder när spel läggs till eller importeras"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Föredra framför officiella bilder"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Föredra animerade bilder"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Uppdatera omslag"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Hämta omslag till spel som redan finns i ditt bibliotek"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Uppdatera"
 
@@ -361,135 +365,136 @@ msgstr "Inga dolda spel"
 msgid "Games you hide will appear here"
 msgstr "Spel som du döljer kommer visas här"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Alla spel"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Tillagt"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Importerad"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Dolda spel"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Speltitel"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Spela"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sortering"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Ö"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Ö-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Nyaste"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Äldsta"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Senast spelad"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Visa dolda"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Om Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} startat"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Micke"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Tillagt: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Aldrig"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Senast spelat: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Tillämpa"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Lägg till nytt spel"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Lägg till"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Körbara filer"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "fil.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\sökväg\\till\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/sökväg/till/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -512,19 +517,19 @@ msgstr ""
 "Om sökvägen innehåller mellanslag, se till att den omsluts av dubbla "
 "citationstecken!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Kunde inte lägga till spelet"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Spelets titel kan inte vara tom."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Den körbara filen kan inte vara tom."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Kunde inte tillämpa inställningar"
 
@@ -538,50 +543,49 @@ msgid "{} unhidden"
 msgstr "{} synlig"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} borttaget"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Alla spel togs bort"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "En API-nyckel krävs för att använda SteamGridDB. Du kan generera en {}här{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Laddar ner omslagsbilder…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Omslagsbilder uppdaterade"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Installation hittades inte"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Välj en giltig katalog"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Varning"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Ogiltig katalog"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Ange plats"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Avvisa"
 
@@ -589,27 +593,29 @@ msgstr "Avvisa"
 msgid "Importing Games…"
 msgstr "Importerar spel…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Följande fel uppstod under importeringen:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Inga nya spel hittades"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 spel Importerat"
+msgid_plural "{} games imported"
+msgstr[0] "1 spel importerat"
+msgstr[1] "{} spel importerade"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} spel importerade"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 borttagen"
+msgid_plural "{} removed"
+msgstr[0] "1 borttagen"
+msgstr[1] "{} borttagna"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -646,6 +652,9 @@ msgstr "Kunde inte autentisera SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Verifiera din API-nyckel i inställningar"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} spel importerade"
 
 #~ msgid "Cache Location"
 #~ msgstr "Plats för cacheminne"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: bittin1ddc447d824349b2 <bittin@reimu.nl>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/cartridges/"
@@ -438,9 +438,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} startat"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Micke"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: bittin1ddc447d824349b2 <bittin@reimu.nl>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/cartridges/"
@@ -66,7 +66,7 @@ msgstr "Redigera speldetaljer"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Inställningar"
 
@@ -132,7 +132,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Tangentbordsgenvägar"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Ångra"
 
@@ -170,7 +170,7 @@ msgid "Remove Game"
 msgstr "Ta bort spel"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Beteende"
 
@@ -207,137 +207,137 @@ msgstr "Farozon"
 msgid "Remove All Games"
 msgstr "Ta bort alla spel"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Ta bort avinstallerade spel"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Källor"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Plats för installation"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Importera Steam-spel"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Importera Flatpak-spel"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Importera Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Importera GOG-spel"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Importera Amazon-spel"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Importera sidoladdade spel"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "System plats"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Användar plats"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Importera spelstartare"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Skrivbordsposter"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API-nyckel"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Använd SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Ladda ner bilder när spel läggs till eller importeras"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Föredra framför officiella bilder"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Föredra animerade bilder"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Uppdatera omslag"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Hämta omslag till spel som redan finns i ditt bibliotek"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Uppdatera"
 
@@ -546,45 +546,45 @@ msgstr "{} synlig"
 msgid "{} removed"
 msgstr "{} borttaget"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Alla spel togs bort"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "En API-nyckel krävs för att använda SteamGridDB. Du kan generera en {}här{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Laddar ner omslagsbilder…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Omslagsbilder uppdaterade"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Installation hittades inte"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Välj en giltig katalog"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Varning"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Ogiltig katalog"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Ange plats"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Avvisa"
 
@@ -592,16 +592,16 @@ msgstr "Avvisa"
 msgid "Importing Games…"
 msgstr "Importerar spel…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Följande fel uppstod under importeringen:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Inga nya spel hittades"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -609,7 +609,7 @@ msgstr[0] "1 spel importerat"
 msgstr[1] "{} spel importerade"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: bittin1ddc447d824349b2 <bittin@reimu.nl>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/cartridges/"
@@ -542,9 +542,13 @@ msgid "{} unhidden"
 msgstr "{} synlig"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} borttaget"
+msgid_plural "{} removed"
+msgstr[0] "{} borttaget"
+msgstr[1] "{} borttaget"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -588,6 +592,32 @@ msgstr "Ange plats"
 msgid "Dismiss"
 msgstr "Avvisa"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Idag"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Igår"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Senast spelad"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Senast spelad"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Importerar spel…"
@@ -603,18 +633,10 @@ msgstr "Inga nya spel hittades"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 spel importerat"
+msgstr[0] "{} spel importerade"
 msgstr[1] "{} spel importerade"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 borttagen"
-msgstr[1] "{} borttagna"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -652,8 +674,17 @@ msgstr "Kunde inte autentisera SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Verifiera din API-nyckel i inställningar"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} spel importerade"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 spel importerat"
+#~ msgstr[1] "{} spel importerade"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 borttagen"
+#~ msgstr[1] "{} borttagna"
 
 #~ msgid "Cache Location"
 #~ msgstr "Plats för cacheminne"
@@ -716,12 +747,6 @@ msgstr "Verifiera din API-nyckel i inställningar"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Bottles-installationsplats"
-
-#~ msgid "Today"
-#~ msgstr "Idag"
-
-#~ msgid "Yesterday"
-#~ msgstr "Igår"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Välj Lutris cache-mapp."

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartridges/"
@@ -541,9 +541,13 @@ msgid "{} unhidden"
 msgstr "{} மறைக்கப்படாதது"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} அகற்றப்பட்டது"
+msgid_plural "{} removed"
+msgstr[0] "{} அகற்றப்பட்டது"
+msgstr[1] "{} அகற்றப்பட்டது"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -586,6 +590,32 @@ msgstr "இருப்பிடத்தை அமைக்கவும்"
 msgid "Dismiss"
 msgstr "நிராகரி"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "இன்று"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "நேற்று"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "கடைசியாக விளையாடியது"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "கடைசியாக விளையாடியது"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "விளையாட்டுகளை இறக்குமதி செய்கிறது…"
@@ -601,18 +631,10 @@ msgstr "புதிய விளையாட்டுகள் எதுவு�
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 விளையாட்டு இறக்குமதி செய்யப்பட்டது"
+msgstr[0] "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
 msgstr[1] "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 அகற்றப்பட்டது"
-msgstr[1] "{} அகற்றப்பட்டது"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -650,8 +672,17 @@ msgstr "SteamGridDB ஐ அங்கீகரிக்க முடியவி�
 msgid "Verify your API key in preferences"
 msgstr "உங்கள் API விசையை விருப்பங்களில் சரிபார்க்கவும்"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 விளையாட்டு இறக்குமதி செய்யப்பட்டது"
+#~ msgstr[1] "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 அகற்றப்பட்டது"
+#~ msgstr[1] "{} அகற்றப்பட்டது"
 
 #~ msgid "kramo"
 #~ msgstr "கிராமோ"
@@ -717,12 +748,6 @@ msgstr "உங்கள் API விசையை விருப்பங்க
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Bottles (பாட்டில்கள்) நிறுவும் இடம்"
-
-#~ msgid "Today"
-#~ msgstr "இன்று"
-
-#~ msgid "Yesterday"
-#~ msgstr "நேற்று"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "தற்காலிக சேமிப்பு கிடைக்கவில்லை"

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartridges/"
@@ -66,7 +66,7 @@ msgstr "விளையாட்டு விவரங்களைத் தி�
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "விருப்பங்கள்"
 
@@ -132,7 +132,7 @@ msgid "Keyboard Shortcuts"
 msgstr "விசைப்பலகை குறுக்குவழிகள்"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "செயல்தவிர்"
 
@@ -170,7 +170,7 @@ msgid "Remove Game"
 msgstr "விளையாட்டை அகற்று"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "நடத்தை"
 
@@ -206,138 +206,138 @@ msgstr "ஆபத்து மண்டலம்"
 msgid "Remove All Games"
 msgstr "அனைத்து விளையாட்டுகளையும் அகற்று"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "நிறுவல் நீக்கப்பட்ட விளையாட்டுகளை அகற்று"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "மூலங்கள்"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "நிறுவல் இடம்"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak கேம்களை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic விளையாட்டுகளை இறக்குமதி செய்"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "பக்க ஏற்றப்பட்ட விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "பாட்டில்கள்"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "கணினி இருப்பிடம்"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "பயனர் இருப்பிடம்"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "விளையாட்டு துவக்கிகளை இறக்குமதி செய்"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "டெஸ்க்டாப் உள்ளீடுகள்"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "அங்கீகாரம்"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API விசை"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB ஐப் பயன்படுத்தவும்"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr ""
 "விளையாட்டுகளைச் சேர்க்கும் போது அல்லது இறக்குமதி செய்யும் போது படங்களைப் பதிவிறக்கவும்"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "அதிகாரப்பூர்வ படங்களை விட முன்னுரிமை"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "இயங்குபடம் செய்யப்பட்ட படங்களுக்கு முன்னுரிமை கொடுங்கள்"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "அட்டைகளை புதுப்பிக்கவும்"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "ஏற்கனவே உங்கள் நூலகத்தில் உள்ள விளையாட்டுகளுக்கான அட்டைகளைப் பெறவும்"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "புதுப்பிக்கவும்"
 
@@ -545,44 +545,44 @@ msgstr "{} மறைக்கப்படாதது"
 msgid "{} removed"
 msgstr "{} அகற்றப்பட்டது"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "அனைத்து விளையாட்டுகளும் அகற்றப்பட்டன"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "SteamGridDB ஐப் பயன்படுத்த API விசை தேவை. நீங்கள் ஒன்றை {}இங்கே{} உருவாக்கலாம்."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "அட்டைகளைப் பதிவிறக்குகிறது…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "அட்டைகள் புதுப்பிக்கப்பட்டன"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "நிறுவல் கிடைக்கவில்லை"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "சரியான கோப்பகத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "எச்சரிக்கை"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "தவறான கோப்பகம்"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "இருப்பிடத்தை அமைக்கவும்"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "நிராகரி"
 
@@ -590,16 +590,16 @@ msgstr "நிராகரி"
 msgid "Importing Games…"
 msgstr "விளையாட்டுகளை இறக்குமதி செய்கிறது…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "இறக்குமதியின் போது பின்வரும் பிழைகள் ஏற்பட்டன:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "புதிய விளையாட்டுகள் எதுவும் கண்டறியப்படவில்லை"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -607,7 +607,7 @@ msgstr[0] "1 விளையாட்டு இறக்குமதி செ�
 msgstr[1] "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartridges/"
@@ -438,9 +438,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} தொடங்கப்பட்டது"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-15 13:10+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartridges/"
@@ -55,8 +55,8 @@ msgstr ""
 "கொண்டுள்ளது. நீங்கள் விளையாட்டுகளை வரிசைப்படுத்தலாம் மற்றும் மறைக்கலாம் அல்லது SteamGridDB "
 "இலிருந்து அட்டைப்பட கலையைப் பதிவிறக்கலாம்."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "விளையாட்டு விவரங்கள்"
 
@@ -65,8 +65,8 @@ msgid "Edit Game Details"
 msgstr "விளையாட்டு விவரங்களைத் திருத்து"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "விருப்பங்கள்"
 
@@ -74,47 +74,47 @@ msgstr "விருப்பங்கள்"
 msgid "Cancel"
 msgstr "ரத்துசெய்"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "புதிய அட்டை"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "அட்டையை நீக்கு"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "தலைப்பு"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "டெவலப்பர் (விரும்பினால்)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "செயல்படுத்தக்கூடியது"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "மேலும் தகவல்"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "தொகு"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "மறை"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "அகற்று"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "மறை காட்டு"
 
@@ -122,17 +122,17 @@ msgstr "மறை காட்டு"
 msgid "General"
 msgstr "பொது"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "தேடு"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "விசைப்பலகை குறுக்குவழிகள்"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "செயல்தவிர்"
 
@@ -140,11 +140,11 @@ msgstr "செயல்தவிர்"
 msgid "Quit"
 msgstr "வெளியேறு"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "பக்கப்பட்டியை நிலைமாற்று"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "முதன்மை பட்டியல்"
 
@@ -152,12 +152,12 @@ msgstr "முதன்மை பட்டியல்"
 msgid "Games"
 msgstr "விளையாட்டுகள்"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "விளையாட்டைச் சேர்க்கவும்"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "இறக்குமதி"
 
@@ -169,8 +169,8 @@ msgstr "மறைக்கப்பட்ட விளையாட்டுக�
 msgid "Remove Game"
 msgstr "விளையாட்டை அகற்று"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "நடத்தை"
 
@@ -186,7 +186,7 @@ msgstr "அட்டைப் படம் விளையாட்டை தொ
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "அட்டைப் படத்தின் நடத்தை மற்றும் பிளே பட்டனை மாற்றுகிறது"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "படங்கள்"
 
@@ -202,138 +202,142 @@ msgstr "சேமிப்பக செலவில் விளையாட்�
 msgid "Danger Zone"
 msgstr "ஆபத்து மண்டலம்"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "அனைத்து விளையாட்டுகளையும் அகற்று"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "நிறுவல் நீக்கப்பட்ட விளையாட்டுகளை அகற்று"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "மூலங்கள்"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "நிறுவல் இடம்"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak கேம்களை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic விளையாட்டுகளை இறக்குமதி செய்"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "பக்க ஏற்றப்பட்ட விளையாட்டுகளை இறக்குமதி செய்யவும்"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "பாட்டில்கள்"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "கணினி இருப்பிடம்"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "பயனர் இருப்பிடம்"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "விளையாட்டு துவக்கிகளை இறக்குமதி செய்"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "டெஸ்க்டாப் உள்ளீடுகள்"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "அங்கீகாரம்"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API விசை"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB ஐப் பயன்படுத்தவும்"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr ""
 "விளையாட்டுகளைச் சேர்க்கும் போது அல்லது இறக்குமதி செய்யும் போது படங்களைப் பதிவிறக்கவும்"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "அதிகாரப்பூர்வ படங்களை விட முன்னுரிமை"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "இயங்குபடம் செய்யப்பட்ட படங்களுக்கு முன்னுரிமை கொடுங்கள்"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "அட்டைகளை புதுப்பிக்கவும்"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "ஏற்கனவே உங்கள் நூலகத்தில் உள்ள விளையாட்டுகளுக்கான அட்டைகளைப் பெறவும்"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "புதுப்பிக்கவும்"
 
@@ -361,135 +365,136 @@ msgstr "மறைக்கப்பட்ட விளையாட்டுக�
 msgid "Games you hide will appear here"
 msgstr "நீங்கள் மறைக்கும் விளையாட்டுகள் இங்கே தோன்றும்"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "அனைத்து விளையாட்டுகள்"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "சேர்க்கப்பட்டது"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "இறக்குமதி செய்யப்பட்டது"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "மறைக்கப்பட்ட விளையாட்டுகள்"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "விளையாட்டு தலைப்பு"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "விளையாடு"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "வகைபடுத்து"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "புதியது"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "பழமையானது"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "கடைசியாக விளையாடியது"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "மறைக்கப்பட்டதைக் காட்டு"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "கார்ட்ரிட்ஜ்கள் பற்றி"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} தொடங்கப்பட்டது"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "சேர்க்கப்பட்டது: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "ஒருபோதும் இல்லை"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "கடைசியாக விளையாடியது: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "விண்ணப்பி"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "புதிய விளையாட்டைச் சேர்க்கவும்"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "சேர்"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "செயல்படுத்தக்கூடியவை"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "கோப்பு.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "பயன்பாடு"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\பாதை\\டு \\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/பாதை/டு/ {}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -511,19 +516,19 @@ msgstr ""
 "\n"
 "பாதையில் இடைவெளிகள் இருந்தால், அதை இரட்டை மேற்கோள்களில் போர்த்துவதை உறுதிசெய்யவும்!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "விளையாட்டைச் சேர்க்க முடியவில்லை"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "விளையாட்டு தலைப்பு காலியாக இருக்கக்கூடாது."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "இயங்கக்கூடியது காலியாக இருக்க முடியாது."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "விருப்பங்களைப் பயன்படுத்த முடியவில்லை"
 
@@ -537,49 +542,48 @@ msgid "{} unhidden"
 msgstr "{} மறைக்கப்படாதது"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} அகற்றப்பட்டது"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "அனைத்து விளையாட்டுகளும் அகற்றப்பட்டன"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "SteamGridDB ஐப் பயன்படுத்த API விசை தேவை. நீங்கள் ஒன்றை {}இங்கே{} உருவாக்கலாம்."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "அட்டைகளைப் பதிவிறக்குகிறது…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "அட்டைகள் புதுப்பிக்கப்பட்டன"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "நிறுவல் கிடைக்கவில்லை"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "சரியான கோப்பகத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "எச்சரிக்கை"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "தவறான கோப்பகம்"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "இருப்பிடத்தை அமைக்கவும்"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "நிராகரி"
 
@@ -587,27 +591,29 @@ msgstr "நிராகரி"
 msgid "Importing Games…"
 msgstr "விளையாட்டுகளை இறக்குமதி செய்கிறது…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "இறக்குமதியின் போது பின்வரும் பிழைகள் ஏற்பட்டன:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "புதிய விளையாட்டுகள் எதுவும் கண்டறியப்படவில்லை"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 விளையாட்டு இறக்குமதி செய்யப்பட்டது"
+msgid_plural "{} games imported"
+msgstr[0] "1 விளையாட்டு இறக்குமதி செய்யப்பட்டது"
+msgstr[1] "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 அகற்றப்பட்டது"
+msgid_plural "{} removed"
+msgstr[0] "1 அகற்றப்பட்டது"
+msgstr[1] "{} அகற்றப்பட்டது"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -644,6 +650,9 @@ msgstr "SteamGridDB ஐ அங்கீகரிக்க முடியவி�
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "உங்கள் API விசையை விருப்பங்களில் சரிபார்க்கவும்"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} விளையாட்டுகள் இறக்குமதி செய்யப்பட்டன"
 
 #~ msgid "kramo"
 #~ msgstr "கிராமோ"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-10-08 10:06+0530\n"
 "Last-Translator: Aryan Karamtoth <aryankmmiv@outlook.com>\n"
 "Language-Team: Telugu\n"
@@ -433,9 +433,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} ప్రారంభించబడింది"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Aryan Karamtoth"
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-10-08 10:06+0530\n"
 "Last-Translator: Aryan Karamtoth <aryankmmiv@outlook.com>\n"
 "Language-Team: Telugu\n"
@@ -51,8 +51,8 @@ msgstr ""
 "మరియు మరిన్నింటి నుండి గేమ్‌లను దిగుమతి చేసుకోవడానికి ఇది మద్దతును కలిగి ఉంది. మీరు గేమ్‌లను "
 "క్రమబద్ధీకరించవచ్చు మరియు దాచవచ్చు లేదా SteamGridDB నుండి కవర్ ఆర్ట్‌ని డౌన్‌లోడ్ చేసుకోవచ్చు."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "గేమ్ వివరాలు"
 
@@ -61,8 +61,8 @@ msgid "Edit Game Details"
 msgstr "గేమ్ వివరాలను సవరించండి"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "ప్రాధాన్యతలు"
 
@@ -70,47 +70,47 @@ msgstr "ప్రాధాన్యతలు"
 msgid "Cancel"
 msgstr "రద్దు చేయి"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "కొత్త కవర్"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "కవర్‌ని తొలగించండి"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "శీర్షిక"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "డెవలపర్ (ఐచ్ఛికం)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "అమలు చేయదగినది"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "ఫైల్‌ని ఎంచుకోండి"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "మరింత సమాచారం"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "సవరించు"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "దాచు"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "తొలగించు"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "దాచిపెట్టు"
 
@@ -118,17 +118,17 @@ msgstr "దాచిపెట్టు"
 msgid "General"
 msgstr "జనరల్"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "శోధించండి"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "కీబోర్డ్ సత్వరమార్గాలు"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "అన్డు"
 
@@ -136,11 +136,11 @@ msgstr "అన్డు"
 msgid "Quit"
 msgstr "నిష్క్రమించు"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "సైడ్‌బార్‌ని టోగుల్ చేయండి"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "ప్రధాన మెనూ"
 
@@ -148,12 +148,12 @@ msgstr "ప్రధాన మెనూ"
 msgid "Games"
 msgstr "ఆటలు"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "గేమ్ జోడించండి"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "దిగుమతి"
 
@@ -165,8 +165,8 @@ msgstr "హిడెన్ గేమ్‌లను చూపించు"
 msgid "Remove Game"
 msgstr "గేమ్‌ని తీసివేయండి"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "ప్రవర్తన"
 
@@ -182,7 +182,7 @@ msgstr "కవర్ ఇమేజ్ గేమ్ లాంచ్"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "కవర్ ఇమేజ్ మరియు ప్లే బటన్ యొక్క ప్రవర్తనను మారుస్తుంది"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "చిత్రాలు"
 
@@ -198,137 +198,141 @@ msgstr "నిల్వ ఖర్చుతో గేమ్ కవర్‌లన
 msgid "Danger Zone"
 msgstr "డేంజర్ జోన్"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "అన్ని ఆటలను తీసివేయండి"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "అన్‌ఇన్‌స్టాల్ చేసిన గేమ్‌లను తీసివేయండి"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "మూలాలు"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "స్టిం"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "స్థానాన్ని ఇన్‌స్టాల్ చేయండి"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "లుట్రిస్"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "స్టిం గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "ఫ్లాట్‌పాక్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "హిరోఇక్"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "ఎపిక్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "అమెజాన్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "సైడ్‌లోడెడ్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "బాటిల్స్"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "ఇచ్చ్"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "లెజెండరీ"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "ఫ్లాట్‌పాక్"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "సిస్టమ్ స్థానం"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "వినియోగదారు స్థానం"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "దిగుమతి గేమ్ లాంచర్లు"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "డెస్క్‌టాప్ ఎంట్రీలు"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "ప్రమాణీకరణ"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API కీ"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDBని ఉపయోగించండి"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "గేమ్‌లను జోడించేటప్పుడు లేదా దిగుమతి చేస్తున్నప్పుడు చిత్రాలను డౌన్‌లోడ్ చేయండి"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "అధికారిక చిత్రాల కంటే ప్రాధాన్యత ఇవ్వండి"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "యానిమేటెడ్ చిత్రాలకు ప్రాధాన్యత ఇవ్వండి"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "కవర్‌లను నవీకరించండి"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "ఇప్పటికే మీ లైబ్రరీలో ఉన్న గేమ్‌ల కోసం కవర్‌లను పొందండి"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "నవీకరించు"
 
@@ -356,135 +360,136 @@ msgstr "హిడెన్ గేమ్‌లు లేవు"
 msgid "Games you hide will appear here"
 msgstr "మీరు దాచిన గేమ్‌లు ఇక్కడ కనిపిస్తాయి"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "అన్ని ఆటలు"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "చేర్చబడింది"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "దిగుమతి చేయబడింది"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "దాచిన ఆటలు"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "గేమ్ శీర్షిక"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "ఆడండి"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "క్రమబద్ధీకరించు"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "సరికొత్త"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "అతి పురాతనమైనది"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "చివరిగా ఆడినది"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "దాచిన చూపు"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "గుళికల గురించి"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} ప్రారంభించబడింది"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Aryan Karamtoth"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "జోడించబడింది: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "ఎప్పుడూ"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "చివరిగా ఆడినది: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "దరఖాస్తు చేసుకోండి"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "కొత్త గేమ్‌ని జోడించండి"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "జోడించు"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "ఎక్జిక్యూటబుల్స్"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "ప్రోగ్రామ్"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\path\\to\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/path/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -506,19 +511,19 @@ msgstr ""
 "\n"
 "మార్గం ఖాళీలను కలిగి ఉన్నట్లయితే, దానిని డబుల్ కోట్‌లలో చుట్టేలా చూసుకోండి!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "గేమ్‌ని జోడించడం సాధ్యపడలేదు"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "గేమ్ శీర్షిక ఖాళీగా ఉండకూడదు."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "ఎక్జిక్యూటబుల్ ఖాళీగా ఉండకూడదు."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "ప్రాధాన్యతలను వర్తింపజేయడం సాధ్యపడలేదు"
 
@@ -532,49 +537,48 @@ msgid "{} unhidden"
 msgstr "{} దాచబడలేదు"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} తీసివేయబడింది"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "అన్ని గేమ్‌లు తీసివేయబడ్డాయి"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "SteamGridDBని ఉపయోగించడానికి API కీ అవసరం. మీరు {}ఇక్కడ{} ఒకదాన్ని రూపొందించవచ్చు."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "కవర్‌లను డౌన్‌లోడ్ చేస్తోంది…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "కవర్లు నవీకరించబడ్డాయి"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "ఇన్‌స్టాలేషన్ కనుగొనబడలేదు"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "చెల్లుబాటు అయ్యే డైరెక్టరీని ఎంచుకోండి"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "హెచ్చరిక"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "చెల్లని డైరెక్టరీ"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "స్థానాన్ని సెట్ చేయండి"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "తొలగించు"
 
@@ -582,27 +586,29 @@ msgstr "తొలగించు"
 msgid "Importing Games…"
 msgstr "గేమ్‌లను దిగుమతి చేస్తోంది..."
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "దిగుమతి సమయంలో క్రింది లోపాలు సంభవించాయి:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "కొత్త గేమ్‌లు ఏవీ కనుగొనబడలేదు"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 గేమ్ దిగుమతి చేయబడింది"
+msgid_plural "{} games imported"
+msgstr[0] "1 గేమ్ దిగుమతి చేయబడింది"
+msgstr[1] "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 తీసివేయబడింది"
+msgid_plural "{} removed"
+msgstr[0] "1 తీసివేయబడింది"
+msgstr[1] "{} తీసివేయబడింది"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -639,3 +645,6 @@ msgstr "SteamGridDB ని ప్రమాణీకరించడం సాధ�
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "ప్రాధాన్యతలలో మీ API కీని ధృవీకరించండి"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-10-08 10:06+0530\n"
 "Last-Translator: Aryan Karamtoth <aryankmmiv@outlook.com>\n"
 "Language-Team: Telugu\n"
@@ -62,7 +62,7 @@ msgstr "గేమ్ వివరాలను సవరించండి"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "ప్రాధాన్యతలు"
 
@@ -128,7 +128,7 @@ msgid "Keyboard Shortcuts"
 msgstr "కీబోర్డ్ సత్వరమార్గాలు"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "అన్డు"
 
@@ -166,7 +166,7 @@ msgid "Remove Game"
 msgstr "గేమ్‌ని తీసివేయండి"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "ప్రవర్తన"
 
@@ -202,137 +202,137 @@ msgstr "డేంజర్ జోన్"
 msgid "Remove All Games"
 msgstr "అన్ని ఆటలను తీసివేయండి"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "అన్‌ఇన్‌స్టాల్ చేసిన గేమ్‌లను తీసివేయండి"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "మూలాలు"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "స్టిం"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "స్థానాన్ని ఇన్‌స్టాల్ చేయండి"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "లుట్రిస్"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "స్టిం గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "ఫ్లాట్‌పాక్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "హిరోఇక్"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "ఎపిక్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "అమెజాన్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "సైడ్‌లోడెడ్ గేమ్‌లను దిగుమతి చేయండి"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "బాటిల్స్"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "ఇచ్చ్"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "లెజెండరీ"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "ఫ్లాట్‌పాక్"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "సిస్టమ్ స్థానం"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "వినియోగదారు స్థానం"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "దిగుమతి గేమ్ లాంచర్లు"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "డెస్క్‌టాప్ ఎంట్రీలు"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "ప్రమాణీకరణ"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API కీ"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDBని ఉపయోగించండి"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "గేమ్‌లను జోడించేటప్పుడు లేదా దిగుమతి చేస్తున్నప్పుడు చిత్రాలను డౌన్‌లోడ్ చేయండి"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "అధికారిక చిత్రాల కంటే ప్రాధాన్యత ఇవ్వండి"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "యానిమేటెడ్ చిత్రాలకు ప్రాధాన్యత ఇవ్వండి"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "కవర్‌లను నవీకరించండి"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "ఇప్పటికే మీ లైబ్రరీలో ఉన్న గేమ్‌ల కోసం కవర్‌లను పొందండి"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "నవీకరించు"
 
@@ -540,44 +540,44 @@ msgstr "{} దాచబడలేదు"
 msgid "{} removed"
 msgstr "{} తీసివేయబడింది"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "అన్ని గేమ్‌లు తీసివేయబడ్డాయి"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "SteamGridDBని ఉపయోగించడానికి API కీ అవసరం. మీరు {}ఇక్కడ{} ఒకదాన్ని రూపొందించవచ్చు."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "కవర్‌లను డౌన్‌లోడ్ చేస్తోంది…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "కవర్లు నవీకరించబడ్డాయి"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "ఇన్‌స్టాలేషన్ కనుగొనబడలేదు"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "చెల్లుబాటు అయ్యే డైరెక్టరీని ఎంచుకోండి"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "హెచ్చరిక"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "చెల్లని డైరెక్టరీ"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "స్థానాన్ని సెట్ చేయండి"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "తొలగించు"
 
@@ -585,16 +585,16 @@ msgstr "తొలగించు"
 msgid "Importing Games…"
 msgstr "గేమ్‌లను దిగుమతి చేస్తోంది..."
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "దిగుమతి సమయంలో క్రింది లోపాలు సంభవించాయి:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "కొత్త గేమ్‌లు ఏవీ కనుగొనబడలేదు"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -602,7 +602,7 @@ msgstr[0] "1 గేమ్ దిగుమతి చేయబడింది"
 msgstr[1] "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-10-08 10:06+0530\n"
 "Last-Translator: Aryan Karamtoth <aryankmmiv@outlook.com>\n"
 "Language-Team: Telugu\n"
@@ -536,9 +536,13 @@ msgid "{} unhidden"
 msgstr "{} దాచబడలేదు"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} తీసివేయబడింది"
+msgid_plural "{} removed"
+msgstr[0] "{} తీసివేయబడింది"
+msgstr[1] "{} తీసివేయబడింది"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -581,6 +585,32 @@ msgstr "స్థానాన్ని సెట్ చేయండి"
 msgid "Dismiss"
 msgstr "తొలగించు"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "చివరిగా ఆడినది"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "చివరిగా ఆడినది"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "గేమ్‌లను దిగుమతి చేస్తోంది..."
@@ -596,18 +626,10 @@ msgstr "కొత్త గేమ్‌లు ఏవీ కనుగొనబడ
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 గేమ్ దిగుమతి చేయబడింది"
+msgstr[0] "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
 msgstr[1] "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 తీసివేయబడింది"
-msgstr[1] "{} తీసివేయబడింది"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -645,5 +667,14 @@ msgstr "SteamGridDB ని ప్రమాణీకరించడం సాధ�
 msgid "Verify your API key in preferences"
 msgstr "ప్రాధాన్యతలలో మీ API కీని ధృవీకరించండి"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 గేమ్ దిగుమతి చేయబడింది"
+#~ msgstr[1] "{} గేమ్‌లు దిగుమతి చేయబడ్డాయి"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 తీసివేయబడింది"
+#~ msgstr[1] "{} తీసివేయబడింది"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2023-12-16 23:25+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/cartridges/"
@@ -437,9 +437,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} başlatıldı"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2023-12-16 23:25+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/cartridges/"
@@ -540,9 +540,13 @@ msgid "{} unhidden"
 msgstr "{} görünür"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} kaldırıldı"
+msgid_plural "{} removed"
+msgstr[0] "{} kaldırıldı"
+msgstr[1] "{} kaldırıldı"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -587,6 +591,32 @@ msgstr "Konum Ayarla"
 msgid "Dismiss"
 msgstr "Vazgeç"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Bugün"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Dün"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Son Oynanan"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Son Oynanan"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Oyunlar İçe Aktarılıyor…"
@@ -602,18 +632,10 @@ msgstr "Yeni oyun bulunamadı"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 oyun içe aktarıldı"
+msgstr[0] "{} oyun içe aktarıldı"
 msgstr[1] "{} oyun içe aktarıldı"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 kaldırıldı"
-msgstr[1] "{} kaldırıldı"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -651,8 +673,17 @@ msgstr "SteamGridDB Kimlik Doğrulaması Yapılamadı"
 msgid "Verify your API key in preferences"
 msgstr "Tercihlerde API anahtarınızı doğrulayın"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} oyun içe aktarıldı"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 oyun içe aktarıldı"
+#~ msgstr[1] "{} oyun içe aktarıldı"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 kaldırıldı"
+#~ msgstr[1] "{} kaldırıldı"
 
 #~ msgid "Cache Location"
 #~ msgstr "Önbellek Konumu"
@@ -717,12 +748,6 @@ msgstr "Tercihlerde API anahtarınızı doğrulayın"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Şişeler Kurulu Konumu"
-
-#~ msgid "Today"
-#~ msgstr "Bugün"
-
-#~ msgid "Yesterday"
-#~ msgstr "Dün"
 
 #~ msgid "Select the Lutris cache directory."
 #~ msgstr "Lutris önbellek dizinini seç."

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2023-12-16 23:25+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/cartridges/"
@@ -53,8 +53,8 @@ msgstr ""
 "aktarma desteğine sahiptir. Oyunları sıralayabilir, gizleyebilir veya "
 "SteamGridDB'den kapak resmi indirebilirsiniz."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Oyun Ayrıntıları"
 
@@ -63,8 +63,8 @@ msgid "Edit Game Details"
 msgstr "Oyun Ayrıntılarını Düzenle"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Tercihler"
 
@@ -72,47 +72,47 @@ msgstr "Tercihler"
 msgid "Cancel"
 msgstr "İptal"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Yeni Kapak"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Kapağı Sil"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Başlık"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Geliştirici (isteğe bağlı)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Yürütülebilir"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Dosya Seç"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Daha Fazla Bilgi"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Düzenle"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Gizle"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Kaldır"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Göster"
 
@@ -120,17 +120,17 @@ msgstr "Göster"
 msgid "General"
 msgstr "Genel"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Ara"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Geri Al"
 
@@ -138,11 +138,11 @@ msgstr "Geri Al"
 msgid "Quit"
 msgstr "Çık"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Kenar Çubuğunu Aç/Kapat"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Ana Menü"
 
@@ -150,12 +150,12 @@ msgstr "Ana Menü"
 msgid "Games"
 msgstr "Oyunlar"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Oyun Ekle"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "İçe Aktar"
 
@@ -167,8 +167,8 @@ msgstr "Gizli Oyunları Göster"
 msgid "Remove Game"
 msgstr "Oyunu Kaldır"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Davranış"
 
@@ -184,7 +184,7 @@ msgstr "Kapak Görüntüsü Oyunu Başlatır"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Kapak görüntüsünün ve oyna düğmesinin davranışını değiştirir"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Görüntüler"
 
@@ -202,137 +202,141 @@ msgstr ""
 msgid "Danger Zone"
 msgstr "Tehlikeli Bölge"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Tüm Oyunları Kaldır"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Kaldırılmış Oyunları Sil"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Kaynaklar"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Kurulu Konumu"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Steam Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Flatpak Oyunlarını İçe Aktarın"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Epic Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "GOG Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Amazon Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Yandan Yüklenmiş Oyunları İçe Aktar"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Şişeler"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Sistem Konumu"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Kullanıcı Konumu"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Oyun Başlatıcıları İçe Aktar"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Masaüstü Girdileri"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Kimlik Doğrulaması"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API anahtarı"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB Kullan"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Oyun eklerken veya içe aktarırken görüntüleri indir"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Resmî Görsellere Yeğle"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Hareketli Görselleri Yeğle"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Kapakları Güncelle"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Zaten kitaplığınızda bulunan oyunların kapaklarını getir"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Güncelle"
 
@@ -360,135 +364,136 @@ msgstr "Gizli Oyun Yok"
 msgid "Games you hide will appear here"
 msgstr "Gizlediğiniz oyunlar burada belirecek"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Tüm Oyunlar"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Eklendi"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "İçe aktarıldı"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Gizli Oyunlar"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Oyun Başlığı"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Oyna"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Sırala"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "A-Z"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Z-A"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "En Yeni"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "En Eski"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Son Oynanan"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Gizlileri Göster"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Kartuşlar Hakkında"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} başlatıldı"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Eklendi: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Asla"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Son oynanma: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Uygula"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Yeni Oyun Ekle"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Ekle"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Yürütülebilirler"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "dosya.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "program"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\yol\\klasör\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/yol/klasör/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -510,19 +515,19 @@ msgstr ""
 "\n"
 "Yol boşluk içeriyorsa, çift tırnak içine aldığınızdan emin olun!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Oyun Eklenemedi"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Oyun başlığı boş olamaz."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Çalıştırılabilir boş olamaz."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Tercihler Uygulanamadı"
 
@@ -536,51 +541,50 @@ msgid "{} unhidden"
 msgstr "{} görünür"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} kaldırıldı"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Tüm oyunlar kaldırıldı"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDBʼyi kullanmak için API anahtarı gereklidir. {}Buradan{} bir tane "
 "oluşturabilirsiniz."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Kapaklar indiriliyor…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Kapaklar güncellendi"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Kurulum Bulunamadı"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Geçerli bir dizin seçin"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Uyarı"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Geçersiz Dizin"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Konum Ayarla"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Vazgeç"
 
@@ -588,27 +592,29 @@ msgstr "Vazgeç"
 msgid "Importing Games…"
 msgstr "Oyunlar İçe Aktarılıyor…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "İçe aktarılırken şu hatalar oluştu:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Yeni oyun bulunamadı"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 oyun içe aktarıldı"
+msgid_plural "{} games imported"
+msgstr[0] "1 oyun içe aktarıldı"
+msgstr[1] "{} oyun içe aktarıldı"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} oyun içe aktarıldı"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 kaldırıldı"
+msgid_plural "{} removed"
+msgstr[0] "1 kaldırıldı"
+msgstr[1] "{} kaldırıldı"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -645,6 +651,9 @@ msgstr "SteamGridDB Kimlik Doğrulaması Yapılamadı"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Tercihlerde API anahtarınızı doğrulayın"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} oyun içe aktarıldı"
 
 #~ msgid "Cache Location"
 #~ msgstr "Önbellek Konumu"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2023-12-16 23:25+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/cartridges/"
@@ -64,7 +64,7 @@ msgstr "Oyun Ayrıntılarını Düzenle"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Tercihler"
 
@@ -130,7 +130,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Geri Al"
 
@@ -168,7 +168,7 @@ msgid "Remove Game"
 msgstr "Oyunu Kaldır"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Davranış"
 
@@ -206,137 +206,137 @@ msgstr "Tehlikeli Bölge"
 msgid "Remove All Games"
 msgstr "Tüm Oyunları Kaldır"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Kaldırılmış Oyunları Sil"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Kaynaklar"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Kurulu Konumu"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Steam Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Flatpak Oyunlarını İçe Aktarın"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Epic Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "GOG Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Amazon Oyunlarını İçe Aktar"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Yandan Yüklenmiş Oyunları İçe Aktar"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Şişeler"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Sistem Konumu"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Kullanıcı Konumu"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Oyun Başlatıcıları İçe Aktar"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Masaüstü Girdileri"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Kimlik Doğrulaması"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API anahtarı"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "SteamGridDB Kullan"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Oyun eklerken veya içe aktarırken görüntüleri indir"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Resmî Görsellere Yeğle"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Hareketli Görselleri Yeğle"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Kapakları Güncelle"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Zaten kitaplığınızda bulunan oyunların kapaklarını getir"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Güncelle"
 
@@ -544,46 +544,46 @@ msgstr "{} görünür"
 msgid "{} removed"
 msgstr "{} kaldırıldı"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Tüm oyunlar kaldırıldı"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "SteamGridDBʼyi kullanmak için API anahtarı gereklidir. {}Buradan{} bir tane "
 "oluşturabilirsiniz."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Kapaklar indiriliyor…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Kapaklar güncellendi"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Kurulum Bulunamadı"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Geçerli bir dizin seçin"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Uyarı"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Geçersiz Dizin"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Konum Ayarla"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Vazgeç"
 
@@ -591,16 +591,16 @@ msgstr "Vazgeç"
 msgid "Importing Games…"
 msgstr "Oyunlar İçe Aktarılıyor…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "İçe aktarılırken şu hatalar oluştu:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Yeni oyun bulunamadı"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -608,7 +608,7 @@ msgstr[0] "1 oyun içe aktarıldı"
 msgstr[1] "{} oyun içe aktarıldı"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: Сергій <sergiy.goncharuk.1@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/cartridges/"
@@ -69,7 +69,7 @@ msgstr "Редагувати інформацію про гру"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "Параметри"
 
@@ -135,7 +135,7 @@ msgid "Keyboard Shortcuts"
 msgstr "Комбінації клавіш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "Відмінити"
 
@@ -173,7 +173,7 @@ msgid "Remove Game"
 msgstr "Видалити гру"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "Поведінка"
 
@@ -209,137 +209,137 @@ msgstr "Небезпечна зона"
 msgid "Remove All Games"
 msgstr "Видалити всі ігри"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "Вилучити видалені ігри"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "Джерела"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "Місце встановлення"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "Імпорт ігор Steam"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "Імпортувати ігри Flatpak"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "Імпорт Epic Games"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "Імпорт ігор GOG"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "Імпортувати ігри Amazon"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "Імпорт сторонніх ігор"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Легендарний"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "Розташування системного каталогу"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "Розташування каталогу користувача"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "Імпортувати ігрові лаунчери"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Записи на робочому столі"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "Аутентифікація"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "Ключ API"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "Використовувати SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "Завантаження зображень під час додавання або імпорту ігор"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "Надавати перевагу офіційним зображенням"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "Надавати перевагу анімованим зображенням"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "Оновити обкладинку"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "Отримані обкладинки для ігор вже у вашій бібліотеці"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "Оновити"
 
@@ -548,46 +548,46 @@ msgstr "{} показано"
 msgid "{} removed"
 msgstr "{} видалено"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "Всі ігри видалено"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для використання SteamGridDB потрібен ключ API. Ви можете згенерувати його {}"
 "тут{}."
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "Завантаження обкладинок…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "Обкладинки оновлені"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "Встановлення не знайдено"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "Виберіть правильний каталог"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "Увага"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "Неправильний каталог"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "Встановити місцезнаходження"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "Відхилити"
 
@@ -595,16 +595,16 @@ msgstr "Відхилити"
 msgid "Importing Games…"
 msgstr "Імпорт ігор…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "Під час імпорту виникли наступні помилки:"
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "Нових ігор не знайдено"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
@@ -613,7 +613,7 @@ msgstr[1] "{} гри імпортовано"
 msgstr[2] "{} гри імпортовано"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: Сергій <sergiy.goncharuk.1@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/cartridges/"
@@ -58,8 +58,8 @@ msgstr ""
 "можете сортувати та приховувати ігри або завантажувати обкладинки з "
 "SteamGridDB."
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "Подробиці гри"
 
@@ -68,8 +68,8 @@ msgid "Edit Game Details"
 msgstr "Редагувати інформацію про гру"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "Параметри"
 
@@ -77,47 +77,47 @@ msgstr "Параметри"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "Нова обкладинка"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "Видалити обкладинку"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "Назва"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "Розробник (необов'язково)"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "Виконуваний"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "Вибрати файл"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "Більше інформації"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "Редагувати"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "Приховати"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "Видалити"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "Показати"
 
@@ -125,17 +125,17 @@ msgstr "Показати"
 msgid "General"
 msgstr "Загальний"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "Пошук"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "Комбінації клавіш"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "Відмінити"
 
@@ -143,11 +143,11 @@ msgstr "Відмінити"
 msgid "Quit"
 msgstr "Вийти"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "Переключити бічну панель"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "Головне меню"
 
@@ -155,12 +155,12 @@ msgstr "Головне меню"
 msgid "Games"
 msgstr "Ігри"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "Додати гру"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "Імпорт"
 
@@ -172,8 +172,8 @@ msgstr "Показати приховані ігри"
 msgid "Remove Game"
 msgstr "Видалити гру"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "Поведінка"
 
@@ -189,7 +189,7 @@ msgstr "Обкладинка запускає гру"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "Міняє місцями поведінку зображення обкладинки та кнопки відтворення"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "Зображення"
 
@@ -205,137 +205,141 @@ msgstr "Збережена гра покривається без втрат з�
 msgid "Danger Zone"
 msgstr "Небезпечна зона"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "Видалити всі ігри"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "Вилучити видалені ігри"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "Джерела"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "Місце встановлення"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "Імпорт ігор Steam"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "Імпортувати ігри Flatpak"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "Імпорт Epic Games"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "Імпорт ігор GOG"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "Імпортувати ігри Amazon"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "Імпорт сторонніх ігор"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Легендарний"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "Розташування системного каталогу"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "Розташування каталогу користувача"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "Імпортувати ігрові лаунчери"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "Записи на робочому столі"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "Аутентифікація"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "Ключ API"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "Використовувати SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "Завантаження зображень під час додавання або імпорту ігор"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "Надавати перевагу офіційним зображенням"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "Надавати перевагу анімованим зображенням"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "Оновити обкладинку"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "Отримані обкладинки для ігор вже у вашій бібліотеці"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "Оновити"
 
@@ -363,135 +367,136 @@ msgstr "Ніяких прихованих ігор"
 msgid "Games you hide will appear here"
 msgstr "Ігри, які ви сховали, з'являться тут"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "Всі Ігри"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "Додано"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "Імпортовано"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "Приховані ігри"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "Назва гри"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "Грати"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "Сортувати"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "А-Я"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "Я-А"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "Найновіші"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "Найстаріші"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "Остання гра"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "Показати приховане"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "Про Картриджі"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "HowLongToBeat"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} запущено"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "kefir2105"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "Додано: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "Ніколи"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "Востаннє грали: {}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "Застосувати"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "Додати нову гру"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "Додати"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "Виконувані файли"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "file.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "програма"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\шлях\\до\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/path/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -514,19 +519,19 @@ msgstr ""
 "\n"
 "Якщо шлях містить пробіли, обов'язково візьміть його в подвійні лапки!"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "Не вдалося додати гру"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "Назва гри не може бути порожньою."
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "Виконуваний файл не може бути порожнім."
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "Не вдалося застосувати параметри"
 
@@ -540,51 +545,50 @@ msgid "{} unhidden"
 msgstr "{} показано"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} видалено"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "Всі ігри видалено"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr ""
 "Для використання SteamGridDB потрібен ключ API. Ви можете згенерувати його {}"
 "тут{}."
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "Завантаження обкладинок…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "Обкладинки оновлені"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "Встановлення не знайдено"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "Виберіть правильний каталог"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "Увага"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "Неправильний каталог"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "Встановити місцезнаходження"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "Відхилити"
 
@@ -592,27 +596,31 @@ msgstr "Відхилити"
 msgid "Importing Games…"
 msgstr "Імпорт ігор…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "Під час імпорту виникли наступні помилки:"
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "Нових ігор не знайдено"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "1 гру імпортовано"
+msgid_plural "{} games imported"
+msgstr[0] "1 гру імпортовано"
+msgstr[1] "{} гри імпортовано"
+msgstr[2] "{} гри імпортовано"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "{} гри імпортовано"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "1 вилучено"
+msgid_plural "{} removed"
+msgstr[0] "1 вилучено"
+msgstr[1] "{} вилучено"
+msgstr[2] "{} вилучено"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -649,6 +657,9 @@ msgstr "Не вдалося автентифікувати SteamGridDB"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "Перевірте свій API-ключ у параметрах"
+
+#~ msgid "{} games imported"
+#~ msgstr "{} гри імпортовано"
 
 #~ msgid "Cache Location"
 #~ msgstr "Розташування кешу"

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: Сергій <sergiy.goncharuk.1@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/cartridges/"
@@ -440,9 +440,8 @@ msgstr "HowLongToBeat"
 msgid "{} launched"
 msgstr "{} запущено"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "kefir2105"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-01-08 09:06+0000\n"
 "Last-Translator: Сергій <sergiy.goncharuk.1@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/cartridges/"
@@ -544,9 +544,14 @@ msgid "{} unhidden"
 msgstr "{} показано"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} видалено"
+msgid_plural "{} removed"
+msgstr[0] "{} видалено"
+msgstr[1] "{} видалено"
+msgstr[2] "{} видалено"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -591,6 +596,32 @@ msgstr "Встановити місцезнаходження"
 msgid "Dismiss"
 msgstr "Відхилити"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr "Сьогодні"
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr "Вчора"
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "Остання гра"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "Остання гра"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "Імпорт ігор…"
@@ -606,20 +637,11 @@ msgstr "Нових ігор не знайдено"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "1 гру імпортовано"
+msgstr[0] "{} гри імпортовано"
 msgstr[1] "{} гри імпортовано"
 msgstr[2] "{} гри імпортовано"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "1 вилучено"
-msgstr[1] "{} вилучено"
-msgstr[2] "{} вилучено"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -657,8 +679,19 @@ msgstr "Не вдалося автентифікувати SteamGridDB"
 msgid "Verify your API key in preferences"
 msgstr "Перевірте свій API-ключ у параметрах"
 
-#~ msgid "{} games imported"
-#~ msgstr "{} гри імпортовано"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "1 гру імпортовано"
+#~ msgstr[1] "{} гри імпортовано"
+#~ msgstr[2] "{} гри імпортовано"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "1 вилучено"
+#~ msgstr[1] "{} вилучено"
+#~ msgstr[2] "{} вилучено"
 
 #~ msgid "Cache Location"
 #~ msgstr "Розташування кешу"
@@ -733,12 +766,6 @@ msgstr "Перевірте свій API-ключ у параметрах"
 
 #~ msgid "Bottles Install Location"
 #~ msgstr "Місце встановлення Bottles"
-
-#~ msgid "Today"
-#~ msgstr "Сьогодні"
-
-#~ msgid "Yesterday"
-#~ msgstr "Вчора"
 
 #~ msgid "Cache Not Found"
 #~ msgstr "Кеш не знайдено"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 17:38+0100\n"
+"POT-Creation-Date: 2024-11-02 23:03+0100\n"
 "PO-Revision-Date: 2024-01-28 19:06+0000\n"
 "Last-Translator: Float <float.hu+@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -538,9 +538,12 @@ msgid "{} unhidden"
 msgstr "{} 已取消隐藏"
 
 #. The variable is the title of the game
-#: cartridges/game.py:153
+#. The variable is the number of games removed. This comes after the text "{} games imported, ".
+#: cartridges/game.py:153 cartridges/importer/importer.py:384
+#, fuzzy
 msgid "{} removed"
-msgstr "{} 已删除"
+msgid_plural "{} removed"
+msgstr[0] "{} 已删除"
 
 #: cartridges/preferences.py:136
 msgid "All games removed"
@@ -583,6 +586,32 @@ msgstr "设置位置"
 msgid "Dismiss"
 msgstr "不考虑"
 
+#: cartridges/utils/relative_date.py:30
+msgid "Today"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:32
+msgid "Yesterday"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:36
+#, fuzzy
+msgid "Last Week"
+msgstr "最后玩过的"
+
+#: cartridges/utils/relative_date.py:38
+msgid "This Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:40
+msgid "Last Month"
+msgstr ""
+
+#: cartridges/utils/relative_date.py:44
+#, fuzzy
+msgid "Last Year"
+msgstr "最后玩过的"
+
 #: cartridges/importer/importer.py:145
 msgid "Importing Games…"
 msgstr "正在导入游戏…"
@@ -598,16 +627,9 @@ msgstr "没有发现新游戏"
 #. The variable is the number of games imported
 #: cartridges/importer/importer.py:380
 #, fuzzy
-msgid "1 game imported"
+msgid "{} game imported"
 msgid_plural "{} games imported"
-msgstr[0] "导入 {} 款游戏"
-
-#. The variable is the number of games removed
-#: cartridges/importer/importer.py:384
-#, fuzzy
-msgid "1 removed"
-msgid_plural "{} removed"
-msgstr[0] "已删除 {} 款游戏"
+msgstr[0] "导入了 {} 个游戏"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -645,8 +667,15 @@ msgstr "SteamGridDB 无法验证您的身份"
 msgid "Verify your API key in preferences"
 msgstr "在偏好设置中验证您的 API 密钥"
 
-#~ msgid "{} games imported"
-#~ msgstr "导入了 {} 个游戏"
+#, fuzzy
+#~ msgid "1 game imported"
+#~ msgid_plural "{} games imported"
+#~ msgstr[0] "导入 {} 款游戏"
+
+#, fuzzy
+#~ msgid "1 removed"
+#~ msgid_plural "{} removed"
+#~ msgstr[0] "已删除 {} 款游戏"
 
 #~ msgid "Cache Location"
 #~ msgstr "缓存位置"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:57+0200\n"
+"POT-Creation-Date: 2024-10-25 21:54+0200\n"
 "PO-Revision-Date: 2024-01-28 19:06+0000\n"
 "Last-Translator: Float <float.hu+@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -435,9 +435,8 @@ msgstr "多久响一次"
 msgid "{} launched"
 msgstr "{} 已启动"
 
-#. Translators: Replace this with your name for it to show up in the about window
+#. Translators: Replace this with Your Name, Your Name <your.email@example.com>, or Your Name https://your-site.com for it to show up in the About dialog.
 #: cartridges/main.py:291
-#, fuzzy
 msgid "translator-credits"
 msgstr "译者名单"
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 12:48+0200\n"
+"POT-Creation-Date: 2024-10-22 12:57+0200\n"
 "PO-Revision-Date: 2024-01-28 19:06+0000\n"
 "Last-Translator: Float <float.hu+@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -53,8 +53,8 @@ msgstr ""
 "Lutris、Heroic等游戏平台导入游戏且无需登录。您可以排序和隐藏游戏，也可以从"
 "SteamGridDB下载封面。"
 
-#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:318
-#: cartridges/details_dialog.py:68
+#: data/page.kramo.Cartridges.metainfo.xml.in:44 data/gtk/window.blp:320
+#: cartridges/details_dialog.py:77
 msgid "Game Details"
 msgstr "游戏详情"
 
@@ -63,8 +63,8 @@ msgid "Edit Game Details"
 msgstr "编辑游戏详情"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
-#: data/gtk/window.blp:542 cartridges/details_dialog.py:267
-#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
+#: data/gtk/window.blp:543 cartridges/details_dialog.py:276
+#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
 msgid "Preferences"
 msgstr "偏好"
 
@@ -72,47 +72,47 @@ msgstr "偏好"
 msgid "Cancel"
 msgstr "取消"
 
-#: data/gtk/details-dialog.blp:46
+#: data/gtk/details-dialog.blp:45
 msgid "New Cover"
 msgstr "新封面"
 
-#: data/gtk/details-dialog.blp:65
+#: data/gtk/details-dialog.blp:64
 msgid "Delete Cover"
 msgstr "删除封面"
 
-#: data/gtk/details-dialog.blp:93 data/gtk/game.blp:81
+#: data/gtk/details-dialog.blp:92 data/gtk/game.blp:80
 msgid "Title"
 msgstr "标题"
 
-#: data/gtk/details-dialog.blp:97
+#: data/gtk/details-dialog.blp:96
 msgid "Developer (optional)"
 msgstr "开发者模式（可选）"
 
-#: data/gtk/details-dialog.blp:103
+#: data/gtk/details-dialog.blp:102
 msgid "Executable"
 msgstr "可执行程序"
 
-#: data/gtk/details-dialog.blp:109
+#: data/gtk/details-dialog.blp:108
 msgid "Select File"
 msgstr "选择文件"
 
-#: data/gtk/details-dialog.blp:120
+#: data/gtk/details-dialog.blp:119
 msgid "More Info"
 msgstr "更多信息"
 
-#: data/gtk/game.blp:102 data/gtk/game.blp:110 data/gtk/window.blp:443
+#: data/gtk/game.blp:101 data/gtk/game.blp:109 data/gtk/window.blp:444
 msgid "Edit"
 msgstr "编辑"
 
-#: data/gtk/game.blp:103 cartridges/window.py:350
+#: data/gtk/game.blp:102 cartridges/window.py:359
 msgid "Hide"
 msgstr "隐藏"
 
-#: data/gtk/game.blp:104 data/gtk/game.blp:112 data/gtk/window.blp:463
+#: data/gtk/game.blp:103 data/gtk/game.blp:111 data/gtk/window.blp:464
 msgid "Remove"
 msgstr "移除"
 
-#: data/gtk/game.blp:111 cartridges/window.py:352
+#: data/gtk/game.blp:110 cartridges/window.py:361
 msgid "Unhide"
 msgstr "取消隐藏"
 
@@ -120,17 +120,17 @@ msgstr "取消隐藏"
 msgid "General"
 msgstr "概要"
 
-#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:205 data/gtk/window.blp:221
-#: data/gtk/window.blp:272 data/gtk/window.blp:288 data/gtk/window.blp:474
+#: data/gtk/help-overlay.blp:14 data/gtk/window.blp:207 data/gtk/window.blp:223
+#: data/gtk/window.blp:274 data/gtk/window.blp:290 data/gtk/window.blp:475
 msgid "Search"
 msgstr "搜索"
 
-#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:543
+#: data/gtk/help-overlay.blp:24 data/gtk/window.blp:544
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:134 cartridges/importer/importer.py:394
+#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
 msgid "Undo"
 msgstr "撤销"
 
@@ -138,11 +138,11 @@ msgstr "撤销"
 msgid "Quit"
 msgstr "退出"
 
-#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:185
+#: data/gtk/help-overlay.blp:39 data/gtk/window.blp:92 data/gtk/window.blp:187
 msgid "Toggle Sidebar"
 msgstr "切换侧边栏"
 
-#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:198 data/gtk/window.blp:265
+#: data/gtk/help-overlay.blp:44 data/gtk/window.blp:200 data/gtk/window.blp:267
 msgid "Main Menu"
 msgstr "主菜单"
 
@@ -150,12 +150,12 @@ msgstr "主菜单"
 msgid "Games"
 msgstr "游戏"
 
-#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:191 data/gtk/window.blp:550
+#: data/gtk/help-overlay.blp:53 data/gtk/window.blp:193 data/gtk/window.blp:551
 msgid "Add Game"
 msgstr "添加游戏"
 
-#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:113
-#: data/gtk/window.blp:27 data/gtk/window.blp:554
+#: data/gtk/help-overlay.blp:58 data/gtk/preferences.blp:58
+#: data/gtk/window.blp:27 data/gtk/window.blp:555
 msgid "Import"
 msgstr "导入"
 
@@ -167,8 +167,8 @@ msgstr "显示隐藏的游戏"
 msgid "Remove Game"
 msgstr "移除游戏"
 
-#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:117
-#: data/gtk/preferences.blp:415
+#: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
+#: data/gtk/preferences.blp:361
 msgid "Behavior"
 msgstr "表现方式"
 
@@ -184,7 +184,7 @@ msgstr "从封面图片启动游戏"
 msgid "Swaps the behavior of the cover image and the play button"
 msgstr "交换封面图像和启动按钮的行为"
 
-#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:82
+#: data/gtk/preferences.blp:26 cartridges/details_dialog.py:91
 msgid "Images"
 msgstr "图像"
 
@@ -200,137 +200,141 @@ msgstr "以存储为代价，无损保存游戏封面"
 msgid "Danger Zone"
 msgstr "危险区域"
 
-#: data/gtk/preferences.blp:48
+#: data/gtk/preferences.blp:39
 msgid "Remove All Games"
 msgstr "移除所有游戏"
 
-#: data/gtk/preferences.blp:120
+#: data/gtk/preferences.blp:47
+msgid "Reset App"
+msgstr ""
+
+#: data/gtk/preferences.blp:65
 msgid "Remove Uninstalled Games"
 msgstr "删除已卸载的游戏"
 
-#: data/gtk/preferences.blp:125
+#: data/gtk/preferences.blp:70
 msgid "Sources"
 msgstr "来源"
 
-#: data/gtk/preferences.blp:128 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:137 data/gtk/preferences.blp:164
-#: data/gtk/preferences.blp:199 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269 data/gtk/preferences.blp:296
-#: data/gtk/preferences.blp:323
+#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
+#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
+#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
+#: data/gtk/preferences.blp:269
 msgid "Install Location"
 msgstr "安装位置"
 
-#: data/gtk/preferences.blp:155 data/gtk/window.blp:564
-#: cartridges/importer/lutris_source.py:96
+#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:181
+#: data/gtk/preferences.blp:127
 msgid "Import Steam Games"
 msgstr "导入 Steam 游戏"
 
-#: data/gtk/preferences.blp:185
+#: data/gtk/preferences.blp:131
 msgid "Import Flatpak Games"
 msgstr "导入 Flatpak 游戏"
 
-#: data/gtk/preferences.blp:190 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:216
+#: data/gtk/preferences.blp:162
 msgid "Import Epic Games"
 msgstr "导入 Epic 游戏"
 
-#: data/gtk/preferences.blp:220
+#: data/gtk/preferences.blp:166
 msgid "Import GOG Games"
 msgstr "导入 GOG 游戏"
 
-#: data/gtk/preferences.blp:224
+#: data/gtk/preferences.blp:170
 msgid "Import Amazon Games"
 msgstr "导入 Amazon 游戏"
 
-#: data/gtk/preferences.blp:228
+#: data/gtk/preferences.blp:174
 msgid "Import Sideloaded Games"
 msgstr "导入 Sideloaded 游戏"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:314 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:341 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:351
+#: data/gtk/preferences.blp:297
 msgid "System Location"
 msgstr "系统位置"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:315
 msgid "User Location"
 msgstr "用户位置"
 
-#: data/gtk/preferences.blp:386
+#: data/gtk/preferences.blp:332
 msgid "Import Game Launchers"
 msgstr "导入游戏启动器"
 
-#: data/gtk/preferences.blp:391 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "桌面项"
 
-#: data/gtk/preferences.blp:403 data/gtk/window.blp:562
+#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:407
+#: data/gtk/preferences.blp:353
 msgid "Authentication"
 msgstr "身份认证"
 
-#: data/gtk/preferences.blp:410
+#: data/gtk/preferences.blp:356
 msgid "API Key"
 msgstr "API 密钥"
 
-#: data/gtk/preferences.blp:418
+#: data/gtk/preferences.blp:364
 msgid "Use SteamGridDB"
 msgstr "使用 SteamGridDB"
 
-#: data/gtk/preferences.blp:419
+#: data/gtk/preferences.blp:365
 msgid "Download images when adding or importing games"
 msgstr "添加或导入游戏时下载图像"
 
-#: data/gtk/preferences.blp:423
+#: data/gtk/preferences.blp:369
 msgid "Prefer Over Official Images"
 msgstr "偏好官方图片"
 
-#: data/gtk/preferences.blp:427
+#: data/gtk/preferences.blp:373
 msgid "Prefer Animated Images"
 msgstr "偏好可活动的图像"
 
-#: data/gtk/preferences.blp:433
+#: data/gtk/preferences.blp:379
 msgid "Update Covers"
 msgstr "更新封面"
 
-#: data/gtk/preferences.blp:434
+#: data/gtk/preferences.blp:380
 msgid "Fetch covers for games already in your library"
 msgstr "获取您库中已有游戏的封面"
 
-#: data/gtk/preferences.blp:439
+#: data/gtk/preferences.blp:385
 msgid "Update"
 msgstr "更新"
 
@@ -358,135 +362,136 @@ msgstr "没有隐藏游戏"
 msgid "Games you hide will appear here"
 msgstr "您隐藏的游戏将出现在这里。"
 
-#: data/gtk/window.blp:76 data/gtk/window.blp:111 cartridges/main.py:228
+#: data/gtk/window.blp:76 data/gtk/window.blp:113 cartridges/main.py:249
 msgid "All Games"
 msgstr "所有游戏"
 
-#: data/gtk/window.blp:136 cartridges/main.py:230
+#: data/gtk/window.blp:140 cartridges/main.py:251
 msgid "Added"
 msgstr "已添加"
 
-#: data/gtk/window.blp:156
+#: data/gtk/window.blp:162
 msgid "Imported"
 msgstr "已导入"
 
-#: data/gtk/window.blp:258
+#: data/gtk/window.blp:260
 msgid "Hidden Games"
 msgstr "隐藏的游戏"
 
-#: data/gtk/window.blp:367
+#: data/gtk/window.blp:368
 msgid "Game Title"
 msgstr "游戏名称"
 
-#: data/gtk/window.blp:424
+#: data/gtk/window.blp:425
 msgid "Play"
 msgstr "启动"
 
-#: data/gtk/window.blp:501
+#: data/gtk/window.blp:502
 msgid "Sort"
 msgstr "分类"
 
-#: data/gtk/window.blp:504
+#: data/gtk/window.blp:505
 msgid "A-Z"
 msgstr "按 A-Z 排序"
 
-#: data/gtk/window.blp:510
+#: data/gtk/window.blp:511
 msgid "Z-A"
 msgstr "按 Z-A 排序"
 
-#: data/gtk/window.blp:516
+#: data/gtk/window.blp:517
 msgid "Newest"
 msgstr "最后添加的"
 
-#: data/gtk/window.blp:522
+#: data/gtk/window.blp:523
 msgid "Oldest"
 msgstr "最先添加的"
 
-#: data/gtk/window.blp:528
+#: data/gtk/window.blp:529
 msgid "Last Played"
 msgstr "最后玩过的"
 
-#: data/gtk/window.blp:535
+#: data/gtk/window.blp:536
 msgid "Show Hidden"
 msgstr "显示隐藏的游戏"
 
-#: data/gtk/window.blp:544
+#: data/gtk/window.blp:545
 msgid "About Cartridges"
 msgstr "关于 Cartridges"
 
-#: data/gtk/window.blp:561
+#: data/gtk/window.blp:562
 msgid "IGDB"
 msgstr "IGDB"
 
-#: data/gtk/window.blp:563
+#: data/gtk/window.blp:564
 msgid "ProtonDB"
 msgstr "ProtonDB"
 
-#: data/gtk/window.blp:565
+#: data/gtk/window.blp:566
 msgid "HowLongToBeat"
 msgstr "多久响一次"
 
 #. The variable is the title of the game
-#: cartridges/main.py:205 cartridges/game.py:125
+#: cartridges/main.py:226 cartridges/game.py:125
 msgid "{} launched"
 msgstr "{} 已启动"
 
 #. Translators: Replace this with your name for it to show up in the about window
-#: cartridges/main.py:270
-msgid "translator_credits"
+#: cartridges/main.py:291
+#, fuzzy
+msgid "translator-credits"
 msgstr "译者名单"
 
 #. The variable is the date when the game was added
-#: cartridges/window.py:373
+#: cartridges/window.py:382
 msgid "Added: {}"
 msgstr "何时添加: {}"
 
-#: cartridges/window.py:376
+#: cartridges/window.py:385
 msgid "Never"
 msgstr "从未"
 
 #. The variable is the date when the game was last played
-#: cartridges/window.py:380
+#: cartridges/window.py:389
 msgid "Last played: {}"
 msgstr "最近一次游玩在：{}"
 
-#: cartridges/details_dialog.py:73
+#: cartridges/details_dialog.py:82
 msgid "Apply"
 msgstr "应用"
 
-#: cartridges/details_dialog.py:79
+#: cartridges/details_dialog.py:88
 msgid "Add New Game"
 msgstr "添加新游戏"
 
-#: cartridges/details_dialog.py:80
+#: cartridges/details_dialog.py:89
 msgid "Add"
 msgstr "添加"
 
-#: cartridges/details_dialog.py:90
+#: cartridges/details_dialog.py:99
 msgid "Executables"
 msgstr "可执行文件"
 
 #. Translate this string as you would translate "file"
-#: cartridges/details_dialog.py:105
+#: cartridges/details_dialog.py:114
 msgid "file.txt"
 msgstr "文件.txt"
 
 #. As in software
-#: cartridges/details_dialog.py:107
+#: cartridges/details_dialog.py:116
 msgid "program"
 msgstr "程序"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:112 cartridges/details_dialog.py:114
+#: cartridges/details_dialog.py:121 cartridges/details_dialog.py:123
 msgid "C:\\path\\to\\{}"
 msgstr "C:\\路径\\到\\{}"
 
 #. Translate this string as you would translate "path to {}"
-#: cartridges/details_dialog.py:118 cartridges/details_dialog.py:120
+#: cartridges/details_dialog.py:127 cartridges/details_dialog.py:129
 msgid "/path/to/{}"
 msgstr "/path/to/{}"
 
-#: cartridges/details_dialog.py:125
+#: cartridges/details_dialog.py:134
 msgid ""
 "To launch the executable \"{}\", use the command:\n"
 "\n"
@@ -508,19 +513,19 @@ msgstr ""
 "\n"
 "如果路径包含空格，请确保将其用双引号引起来！"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:173
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:182
 msgid "Couldn't Add Game"
 msgstr "无法添加游戏"
 
-#: cartridges/details_dialog.py:167 cartridges/details_dialog.py:209
+#: cartridges/details_dialog.py:176 cartridges/details_dialog.py:218
 msgid "Game title cannot be empty."
 msgstr "游戏标题不能为空。"
 
-#: cartridges/details_dialog.py:173 cartridges/details_dialog.py:217
+#: cartridges/details_dialog.py:182 cartridges/details_dialog.py:226
 msgid "Executable cannot be empty."
 msgstr "可执行文件不能为空。"
 
-#: cartridges/details_dialog.py:208 cartridges/details_dialog.py:216
+#: cartridges/details_dialog.py:217 cartridges/details_dialog.py:225
 msgid "Couldn't Apply Preferences"
 msgstr "无法应用偏好设置"
 
@@ -534,49 +539,48 @@ msgid "{} unhidden"
 msgstr "{} 已取消隐藏"
 
 #. The variable is the title of the game
-#. The variable is the number of games removed
-#: cartridges/game.py:153 cartridges/importer/importer.py:391
+#: cartridges/game.py:153
 msgid "{} removed"
 msgstr "{} 已删除"
 
-#: cartridges/preferences.py:133
+#: cartridges/preferences.py:135
 msgid "All games removed"
 msgstr "所有游戏均已删除"
 
-#: cartridges/preferences.py:181
+#: cartridges/preferences.py:187
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "使用 SteamGridDB 需要 API 密钥。 您可以在{}此处{}生成一个。"
 
-#: cartridges/preferences.py:196
+#: cartridges/preferences.py:202
 msgid "Downloading covers…"
 msgstr "正在下载封面…"
 
-#: cartridges/preferences.py:215
+#: cartridges/preferences.py:221
 msgid "Covers updated"
 msgstr "封面已更新"
 
-#: cartridges/preferences.py:360
+#: cartridges/preferences.py:368
 msgid "Installation Not Found"
 msgstr "未找到安装程序"
 
-#: cartridges/preferences.py:361
+#: cartridges/preferences.py:369
 msgid "Select a valid directory"
 msgstr "选择一个有效的目录。"
 
-#: cartridges/preferences.py:397 cartridges/importer/importer.py:318
+#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
 msgid "Warning"
 msgstr "警告"
 
-#: cartridges/preferences.py:431
+#: cartridges/preferences.py:439
 msgid "Invalid Directory"
 msgstr "无效的目录"
 
-#: cartridges/preferences.py:437
+#: cartridges/preferences.py:445
 msgid "Set Location"
 msgstr "设置位置"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
 msgid "Dismiss"
 msgstr "不考虑"
 
@@ -584,27 +588,27 @@ msgstr "不考虑"
 msgid "Importing Games…"
 msgstr "正在导入游戏…"
 
-#: cartridges/importer/importer.py:338
+#: cartridges/importer/importer.py:339
 msgid "The following errors occured during import:"
 msgstr "导入过程中出现以下错误："
 
-#: cartridges/importer/importer.py:367
+#: cartridges/importer/importer.py:368
 msgid "No new games found"
 msgstr "没有发现新游戏"
 
-#: cartridges/importer/importer.py:379
+#. The variable is the number of games imported
+#: cartridges/importer/importer.py:381
+#, fuzzy
 msgid "1 game imported"
-msgstr "导入 1 款游戏"
+msgid_plural "{} games imported"
+msgstr[0] "导入 {} 款游戏"
 
-#. The variable is the number of games
-#: cartridges/importer/importer.py:383
-msgid "{} games imported"
-msgstr "导入了 {} 个游戏"
-
-#. A single game removed
-#: cartridges/importer/importer.py:387
+#. The variable is the number of games removed
+#: cartridges/importer/importer.py:385
+#, fuzzy
 msgid "1 removed"
-msgstr "已删除 1 款游戏"
+msgid_plural "{} removed"
+msgstr[0] "已删除 {} 款游戏"
 
 #. The variable is the name of the source
 #: cartridges/importer/location.py:34
@@ -641,6 +645,9 @@ msgstr "SteamGridDB 无法验证您的身份"
 #: cartridges/store/managers/sgdb_manager.py:47
 msgid "Verify your API key in preferences"
 msgstr "在偏好设置中验证您的 API 密钥"
+
+#~ msgid "{} games imported"
+#~ msgstr "导入了 {} 个游戏"
 
 #~ msgid "Cache Location"
 #~ msgstr "缓存位置"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cartridges\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 21:54+0200\n"
+"POT-Creation-Date: 2024-10-31 17:38+0100\n"
 "PO-Revision-Date: 2024-01-28 19:06+0000\n"
 "Last-Translator: Float <float.hu+@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -64,7 +64,7 @@ msgstr "编辑游戏详情"
 
 #: data/page.kramo.Cartridges.metainfo.xml.in:52 data/gtk/help-overlay.blp:19
 #: data/gtk/window.blp:543 cartridges/details_dialog.py:276
-#: cartridges/importer/importer.py:321 cartridges/importer/importer.py:371
+#: cartridges/importer/importer.py:320 cartridges/importer/importer.py:370
 msgid "Preferences"
 msgstr "偏好"
 
@@ -130,7 +130,7 @@ msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
 #: data/gtk/help-overlay.blp:29 cartridges/game.py:103
-#: cartridges/preferences.py:136 cartridges/importer/importer.py:388
+#: cartridges/preferences.py:137 cartridges/importer/importer.py:387
 msgid "Undo"
 msgstr "撤销"
 
@@ -168,7 +168,7 @@ msgid "Remove Game"
 msgstr "移除游戏"
 
 #: data/gtk/preferences.blp:13 data/gtk/preferences.blp:62
-#: data/gtk/preferences.blp:361
+#: data/gtk/preferences.blp:365
 msgid "Behavior"
 msgstr "表现方式"
 
@@ -204,137 +204,137 @@ msgstr "危险区域"
 msgid "Remove All Games"
 msgstr "移除所有游戏"
 
-#: data/gtk/preferences.blp:47
-msgid "Reset App"
+#: data/gtk/preferences.blp:65
+msgid "Import Games Automatically"
 msgstr ""
 
-#: data/gtk/preferences.blp:65
+#: data/gtk/preferences.blp:69
 msgid "Remove Uninstalled Games"
 msgstr "删除已卸载的游戏"
 
-#: data/gtk/preferences.blp:70
+#: data/gtk/preferences.blp:74
 msgid "Sources"
 msgstr "来源"
 
-#: data/gtk/preferences.blp:74 cartridges/importer/steam_source.py:114
+#: data/gtk/preferences.blp:78 cartridges/importer/steam_source.py:114
 msgid "Steam"
 msgstr "Steam"
 
-#: data/gtk/preferences.blp:83 data/gtk/preferences.blp:110
-#: data/gtk/preferences.blp:145 data/gtk/preferences.blp:188
-#: data/gtk/preferences.blp:215 data/gtk/preferences.blp:242
-#: data/gtk/preferences.blp:269
+#: data/gtk/preferences.blp:87 data/gtk/preferences.blp:114
+#: data/gtk/preferences.blp:149 data/gtk/preferences.blp:192
+#: data/gtk/preferences.blp:219 data/gtk/preferences.blp:246
+#: data/gtk/preferences.blp:273
 msgid "Install Location"
 msgstr "安装位置"
 
-#: data/gtk/preferences.blp:101 data/gtk/window.blp:565
+#: data/gtk/preferences.blp:105 data/gtk/window.blp:565
 #: cartridges/importer/lutris_source.py:107
 msgid "Lutris"
 msgstr "Lutris"
 
-#: data/gtk/preferences.blp:127
+#: data/gtk/preferences.blp:131
 msgid "Import Steam Games"
 msgstr "导入 Steam 游戏"
 
-#: data/gtk/preferences.blp:131
+#: data/gtk/preferences.blp:135
 msgid "Import Flatpak Games"
 msgstr "导入 Flatpak 游戏"
 
-#: data/gtk/preferences.blp:136 cartridges/importer/heroic_source.py:355
+#: data/gtk/preferences.blp:140 cartridges/importer/heroic_source.py:355
 msgid "Heroic"
 msgstr "Heroic"
 
-#: data/gtk/preferences.blp:162
+#: data/gtk/preferences.blp:166
 msgid "Import Epic Games"
 msgstr "导入 Epic 游戏"
 
-#: data/gtk/preferences.blp:166
+#: data/gtk/preferences.blp:170
 msgid "Import GOG Games"
 msgstr "导入 GOG 游戏"
 
-#: data/gtk/preferences.blp:170
+#: data/gtk/preferences.blp:174
 msgid "Import Amazon Games"
 msgstr "导入 Amazon 游戏"
 
-#: data/gtk/preferences.blp:174
+#: data/gtk/preferences.blp:178
 msgid "Import Sideloaded Games"
 msgstr "导入 Sideloaded 游戏"
 
-#: data/gtk/preferences.blp:179 cartridges/importer/bottles_source.py:86
+#: data/gtk/preferences.blp:183 cartridges/importer/bottles_source.py:86
 msgid "Bottles"
 msgstr "Bottles"
 
-#: data/gtk/preferences.blp:206 cartridges/importer/itch_source.py:81
+#: data/gtk/preferences.blp:210 cartridges/importer/itch_source.py:81
 msgid "itch"
 msgstr "itch"
 
-#: data/gtk/preferences.blp:233 cartridges/importer/legendary_source.py:97
+#: data/gtk/preferences.blp:237 cartridges/importer/legendary_source.py:97
 msgid "Legendary"
 msgstr "Legendary"
 
-#: data/gtk/preferences.blp:260 cartridges/importer/retroarch_source.py:142
+#: data/gtk/preferences.blp:264 cartridges/importer/retroarch_source.py:142
 msgid "RetroArch"
 msgstr "RetroArch"
 
-#: data/gtk/preferences.blp:287 cartridges/importer/flatpak_source.py:143
+#: data/gtk/preferences.blp:291 cartridges/importer/flatpak_source.py:143
 msgid "Flatpak"
 msgstr "Flatpak"
 
 #. The location of the system-wide data directory
-#: data/gtk/preferences.blp:297
+#: data/gtk/preferences.blp:301
 msgid "System Location"
 msgstr "系统位置"
 
 #. The location of the user-specific data directory
-#: data/gtk/preferences.blp:315
+#: data/gtk/preferences.blp:319
 msgid "User Location"
 msgstr "用户位置"
 
-#: data/gtk/preferences.blp:332
+#: data/gtk/preferences.blp:336
 msgid "Import Game Launchers"
 msgstr "导入游戏启动器"
 
-#: data/gtk/preferences.blp:337 cartridges/importer/desktop_source.py:215
+#: data/gtk/preferences.blp:341 cartridges/importer/desktop_source.py:215
 msgid "Desktop Entries"
 msgstr "桌面项"
 
-#: data/gtk/preferences.blp:349 data/gtk/window.blp:563
+#: data/gtk/preferences.blp:353 data/gtk/window.blp:563
 msgid "SteamGridDB"
 msgstr "SteamGridDB"
 
-#: data/gtk/preferences.blp:353
+#: data/gtk/preferences.blp:357
 msgid "Authentication"
 msgstr "身份认证"
 
-#: data/gtk/preferences.blp:356
+#: data/gtk/preferences.blp:360
 msgid "API Key"
 msgstr "API 密钥"
 
-#: data/gtk/preferences.blp:364
+#: data/gtk/preferences.blp:368
 msgid "Use SteamGridDB"
 msgstr "使用 SteamGridDB"
 
-#: data/gtk/preferences.blp:365
+#: data/gtk/preferences.blp:369
 msgid "Download images when adding or importing games"
 msgstr "添加或导入游戏时下载图像"
 
-#: data/gtk/preferences.blp:369
+#: data/gtk/preferences.blp:373
 msgid "Prefer Over Official Images"
 msgstr "偏好官方图片"
 
-#: data/gtk/preferences.blp:373
+#: data/gtk/preferences.blp:377
 msgid "Prefer Animated Images"
 msgstr "偏好可活动的图像"
 
-#: data/gtk/preferences.blp:379
+#: data/gtk/preferences.blp:383
 msgid "Update Covers"
 msgstr "更新封面"
 
-#: data/gtk/preferences.blp:380
+#: data/gtk/preferences.blp:384
 msgid "Fetch covers for games already in your library"
 msgstr "获取您库中已有游戏的封面"
 
-#: data/gtk/preferences.blp:385
+#: data/gtk/preferences.blp:389
 msgid "Update"
 msgstr "更新"
 
@@ -542,44 +542,44 @@ msgstr "{} 已取消隐藏"
 msgid "{} removed"
 msgstr "{} 已删除"
 
-#: cartridges/preferences.py:135
+#: cartridges/preferences.py:136
 msgid "All games removed"
 msgstr "所有游戏均已删除"
 
-#: cartridges/preferences.py:187
+#: cartridges/preferences.py:188
 msgid ""
 "An API key is required to use SteamGridDB. You can generate one {}here{}."
 msgstr "使用 SteamGridDB 需要 API 密钥。 您可以在{}此处{}生成一个。"
 
-#: cartridges/preferences.py:202
+#: cartridges/preferences.py:203
 msgid "Downloading covers…"
 msgstr "正在下载封面…"
 
-#: cartridges/preferences.py:221
+#: cartridges/preferences.py:222
 msgid "Covers updated"
 msgstr "封面已更新"
 
-#: cartridges/preferences.py:368
+#: cartridges/preferences.py:370
 msgid "Installation Not Found"
 msgstr "未找到安装程序"
 
-#: cartridges/preferences.py:369
+#: cartridges/preferences.py:371
 msgid "Select a valid directory"
 msgstr "选择一个有效的目录。"
 
-#: cartridges/preferences.py:405 cartridges/importer/importer.py:319
+#: cartridges/preferences.py:407 cartridges/importer/importer.py:318
 msgid "Warning"
 msgstr "警告"
 
-#: cartridges/preferences.py:439
+#: cartridges/preferences.py:441
 msgid "Invalid Directory"
 msgstr "无效的目录"
 
-#: cartridges/preferences.py:445
+#: cartridges/preferences.py:447
 msgid "Set Location"
 msgstr "设置位置"
 
-#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:320
+#: cartridges/utils/create_dialog.py:33 cartridges/importer/importer.py:319
 msgid "Dismiss"
 msgstr "不考虑"
 
@@ -587,23 +587,23 @@ msgstr "不考虑"
 msgid "Importing Games…"
 msgstr "正在导入游戏…"
 
-#: cartridges/importer/importer.py:339
+#: cartridges/importer/importer.py:338
 msgid "The following errors occured during import:"
 msgstr "导入过程中出现以下错误："
 
-#: cartridges/importer/importer.py:368
+#: cartridges/importer/importer.py:367
 msgid "No new games found"
 msgstr "没有发现新游戏"
 
 #. The variable is the number of games imported
-#: cartridges/importer/importer.py:381
+#: cartridges/importer/importer.py:380
 #, fuzzy
 msgid "1 game imported"
 msgid_plural "{} games imported"
 msgstr[0] "导入 {} 款游戏"
 
 #. The variable is the number of games removed
-#: cartridges/importer/importer.py:385
+#: cartridges/importer/importer.py:384
 #, fuzzy
 msgid "1 removed"
 msgid_plural "{} removed"


### PR DESCRIPTION
Compare #298.

This also updates the .po files, changes the translator-credits string to be the same as other GNOME apps, makes it properly be added to the about dialog, and adds a note to translators for _how_ they should add their names.

The translations for the plural forms are definitely not correct in all languages except English US and Norwegian Bokmål. The rest are marked as fuzzy, even if I tried to make sure they still work in all languages.