### PR TITLE
Save covers directly into covers dir

### DIFF
--- a/cartridges/details_dialog.py
+++ b/cartridges/details_dialog.py
@@ -240,6 +240,7 @@ class DetailsDialog(Adw.Dialog):
             save_cover(
                 self.game.game_id,
                 self.game_cover.path,
+                self.game_cover.pixbuf,
             )
 
         shared.store.add_game(self.game, {}, run_pipeline=False)
@@ -304,17 +305,17 @@ class DetailsDialog(Adw.Dialog):
             except UnidentifiedImageError:
                 pass
 
-            if not new_path:
-                new_path = convert_cover(
+            if new_path:
+                self.game_cover.new_cover(new_path)
+            else:
+                self.game_cover.new_cover(
                     pixbuf=shared.store.managers[CoverManager].composite_cover(
                         Path(path)
                     )
                 )
 
-            if new_path:
-                self.game_cover.new_cover(new_path)
-                self.cover_button_delete_revealer.set_reveal_child(True)
-                self.cover_changed = True
+            self.cover_button_delete_revealer.set_reveal_child(True)
+            self.cover_changed = True
 
             self.toggle_loading()
 

--- a/cartridges/game_cover.py
+++ b/cartridges/game_cover.py
@@ -45,12 +45,22 @@ class GameCover:
         self.pictures = pictures
         self.new_cover(path)
 
-    def new_cover(self, path: Optional[Path] = None) -> None:
+    def new_cover(
+        self,
+        path: Optional[Path] = None,
+        pixbuf: Optional[GdkPixbuf.Pixbuf] = None
+    ) -> None:
         self.animation = None
         self.texture = None
         self.blurred = None
         self.luminance = None
         self.path = path
+        self.pixbuf = pixbuf
+
+        if pixbuf:
+             self.texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+             self.set_texture(self.texture)
+             return
 
         if path:
             if path.suffix == ".gif":

--- a/cartridges/store/managers/cover_manager.py
+++ b/cartridges/store/managers/cover_manager.py
@@ -192,7 +192,5 @@ class CoverManager(Manager):
 
             save_cover(
                 game.game_id,
-                convert_cover(
-                    pixbuf=self.composite_cover(image_path, **composite_kwargs)
-                ),
+                pixbuf=self.composite_cover(image_path, **composite_kwargs),
             )


### PR DESCRIPTION
Instead of saving the pixbuf of the new cover into a temporary file and then copy into covers dir, save it directly to there. Without this, a lot of temporary files are created on import, which remain on the system even after the application is closed.