### PR TITLE
fix: increase max-children-per-line to better use high resolution monitors

### DIFF
--- a/data/gtk/window.blp
+++ b/data/gtk/window.blp
@@ -246,6 +246,7 @@ template $CartridgesWindow: Adw.ApplicationWindow {
                   margin-start: 15;
                   margin-end: 15;
                   selection-mode: none;
+                  max-children-per-line: 20;
                 }
               }
             }


### PR DESCRIPTION
# Why? 
The default max-children-per-line seems to be 7, which results in a lot of empty spaces on the sides when full-screen on a high resolution monitor. 

# What?
I increased the max number of children per line in the FlowBox, which uses all the available space on my 4k monitor. The magic number for my monitor is `14`, but I suspect that people with `32:9` monitors will benefit from the max being `20`.

## Issues
This fixes an issue I opened:
 - Fixes: https://github.com/kra-mo/cartridges/issues/318