### PR TITLE
Add additional PackageManager category

### DIFF
--- a/data/page.kramo.Cartridges.desktop.in
+++ b/data/page.kramo.Cartridges.desktop.in
@@ -6,6 +6,6 @@ Exec=cartridges
 Icon=@APP_ID@
 Terminal=false
 Type=Application
-Categories=GNOME;GTK;Game;
+Categories=GNOME;GTK;Game;PackageManager;
 Keywords=gaming;launcher;steam;lutris;heroic;bottles;itch;flatpak;legendary;retroarch;
 StartupNotify=true


### PR DESCRIPTION
Hey, 

I know `PackageManager` doesn't fit 100%, but this will move the app over to the Game Launcher category on flathub

Cheers