### PR TITLE
fix: cast games_count to string in Gtk.Label to fix crash on startup

### DIFF
--- a/cartridges/window.py
+++ b/cartridges/window.py
@@ -162,7 +162,7 @@ class CartridgesWindow(Adw.ApplicationWindow):
 
             row.append(
                 games_no_label := Gtk.Label(
-                    label=games_no,
+                    label=str(games_no),
                     hexpand=True,
                     halign=Gtk.Align.END,
                 )


### PR DESCRIPTION
This change fixes a TypeError that prevents the application from  launching on systems with newer environments (like CachyOS/Arch  running Python 3.14). 

Strict type checking in recent PyGObject versions no longer  automatically converts integers to strings for Gtk.Label.  The application would fail to start with: 
"TypeError: Must be string, not int" 
during the source row creation.